### PR TITLE
fix: Make file input ids unique for post create/profile pic

### DIFF
--- a/src/features/photo/components/PhotoDropArea.tsx
+++ b/src/features/photo/components/PhotoDropArea.tsx
@@ -48,7 +48,7 @@ export default function PhotoDropArea({
       </div>
       <div className="relative w-fit">
         <label
-          htmlFor="file_input"
+          htmlFor="post_photo_input"
           className="px-6 py-1.5 bg-blue-500 disabled:bg-blue-400 hover:bg-blue-600 rounded-xl text-lg font-semibold text-white cursor-pointer select-none"
         >
           {!dropError ? "Select from computer" : "Select other files"}
@@ -62,7 +62,7 @@ export default function PhotoDropArea({
         </div>
         <Input
           {...getInputProps({
-            id: "file_input",
+            id: "post_photo_input",
             type: "file",
             className: "hidden",
           })}

--- a/src/features/profiles/components/ProfilePicInput.tsx
+++ b/src/features/profiles/components/ProfilePicInput.tsx
@@ -169,7 +169,7 @@ export default function ProfilePicInput() {
       <form onChange={handleSubmit(onSubmit, onInvalid)}>
         <Input
           {...profilePicRest}
-          id="file_input"
+          id="profile_pic_input"
           type="file"
           className="hidden"
           ref={(e) => {


### PR DESCRIPTION
Profile pic and Post create modal file inputs were sharing the same id. Attempting to add photo, while viewing currently logged in user's profile, would trigger a profile picture change. This PR changes id for both inputs to more distinct ones.