### PR TITLE
feat: Improve photo scaling and visibility in PostModal

### DIFF
--- a/src/features/core/components/Modal.tsx
+++ b/src/features/core/components/Modal.tsx
@@ -34,7 +34,7 @@ export default function Modal({
         transition
         className="fixed inset-0 bg-black/30 duration-150 ease-out data-[closed]:opacity-0"
       />
-      <div className="fixed inset-0 flex w-screen items-center justify-center py-4 sm:p-4">
+      <div className="fixed inset-0 flex w-screen items-center justify-center pt-10 pb-4 sm:p-4">
         <Button
           title="Close"
           onClick={onClose}

--- a/src/features/core/components/PhotoSlide.tsx
+++ b/src/features/core/components/PhotoSlide.tsx
@@ -2,12 +2,14 @@ import { useState } from "react";
 import Photo from "../types/photo";
 import { Button } from "@headlessui/react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
+import useBreakpoint from "../hooks/useBreakpoint";
 
 type PhotoSlideProps = {
   photos: Photo[];
 };
 
 export default function PhotoSlide({ photos }: PhotoSlideProps) {
+  const isSmBreakpoint = useBreakpoint("sm");
   const [currentPhotoIndex, setCurrentPhotoIndex] = useState(0);
   const currentPhoto = photos[currentPhotoIndex];
 
@@ -26,43 +28,60 @@ export default function PhotoSlide({ photos }: PhotoSlideProps) {
     }
   };
 
+  const containerStyle =
+    isSmBreakpoint ?
+      {
+        aspectRatio: currentPhoto.width / currentPhoto.height,
+        maxHeight: `min(${currentPhoto.height}px, calc(100vh - 2.5rem))`,
+        maxWidth: `min(${currentPhoto.width}px, 100vw)`,
+      }
+    : {
+        aspectRatio: currentPhoto.width / currentPhoto.height,
+        maxHeight: `min(${currentPhoto.height}px, calc(100vh - 14rem))`,
+        maxWidth: `min(${currentPhoto.width}px, 100vw)`,
+      };
+
   return (
-    <div className="relative w-full">
-      {currentPhoto ?
-        <img
-          src={currentPhoto.url}
-          alt={currentPhoto.altText}
-          className="w-full h-full object-cover"
-        />
-      : null}
-
-      {currentPhotoIndex > 0 ?
-        <Button
-          onClick={handlePrevious}
-          className="absolute left-0 top-0 bottom-0 p-1 text-gray-200"
-        >
-          <ChevronLeftIcon className="size-6" />
-        </Button>
-      : null}
-      {currentPhotoIndex < photos.length - 1 ?
-        <Button
-          onClick={handleNext}
-          className="absolute right-0 top-0 bottom-0 p-1 text-gray-200"
-        >
-          <ChevronRightIcon className="size-6" />
-        </Button>
-      : null}
-
-      {photos.length > 1 ?
-        <div className="absolute bottom-3 w-full flex flex-row justify-center items-center gap-1">
-          {[...Array(photos.length).keys()].map((item) => (
-            <div
-              key={item}
-              className={`size-1.5 rounded-full transition ${item === currentPhotoIndex ? "bg-gray-200 " : "bg-gray-400"}`}
+    <div className="w-fit h-fit" style={containerStyle}>
+      <div className="relative w-full h-full">
+        <div className="w-full h-full">
+          {currentPhoto ?
+            <img
+              src={currentPhoto.url}
+              alt={currentPhoto.altText}
+              className="mx-auto h-full object-cover"
             />
-          ))}
+          : null}
         </div>
-      : null}
+
+        {currentPhotoIndex > 0 ?
+          <Button
+            onClick={handlePrevious}
+            className="absolute left-0 top-0 bottom-0 p-1 text-gray-200"
+          >
+            <ChevronLeftIcon className="size-6" />
+          </Button>
+        : null}
+        {currentPhotoIndex < photos.length - 1 ?
+          <Button
+            onClick={handleNext}
+            className="absolute right-0 top-0 bottom-0 p-1 text-gray-200"
+          >
+            <ChevronRightIcon className="size-6" />
+          </Button>
+        : null}
+
+        {photos.length > 1 ?
+          <div className="absolute bottom-3 w-full flex flex-row justify-center items-center gap-1">
+            {[...Array(photos.length).keys()].map((item) => (
+              <div
+                key={item}
+                className={`size-1.5 rounded-full transition ${item === currentPhotoIndex ? "bg-gray-200 " : "bg-gray-400"}`}
+              />
+            ))}
+          </div>
+        : null}
+      </div>
     </div>
   );
 }

--- a/src/features/core/components/PostModal.tsx
+++ b/src/features/core/components/PostModal.tsx
@@ -106,7 +106,7 @@ export default function PostModal({
       />
 
       <Modal isOpen={isOpen} onClose={onClose}>
-        <div className="w-full lg:max-w-[80rem] xl:max-w-[92rem] h-fit sm:h-[calc(100vh-theme(space.10))] flex flex-col sm:flex-row justify-center items-center rounded-b-xl transition">
+        <div className="w-full lg:max-w-[80rem] xl:max-w-[92rem] max-h-[calc(100vh-theme(space.10))] sm:h-[calc(100vh-theme(space.10))] flex flex-col sm:flex-row justify-center items-center rounded-b-xl transition">
           {!isSmBreakpoint ?
             <div className="w-full flex flex-row justify-between items-center px-3 py-2 border-b border-slate-300 dark:border-slate-600">
               {post?.user ?
@@ -120,13 +120,10 @@ export default function PostModal({
             </div>
           : null}
 
-          {/* // todo: aspect in div below */}
-          <div className="max-w-3xl h-full flex flex-col flex-grow items-center justify-center border-r border-slate-300 dark:border-slate-600">
-            <PhotoSlide photos={photos} />
-          </div>
+          <PhotoSlide photos={photos} />
 
-          <div className="w-full sm:w-80 xl:w-[28rem] h-full flex flex-row">
-            <div className="w-full h-full flex-grow flex flex-col">
+          <div className="w-full sm:w-80 xl:w-[26rem] h-full flex flex-row sm:basis-80 xl:basis-[26rem] shrink-0 border-l border-slate-300 dark:border-slate-600">
+            <div className="flex flex-col grow">
               {isSmBreakpoint ?
                 <div className="w-full flex flex-row justify-between items-center px-3 py-2 border-b border-slate-300 dark:border-slate-600">
                   {post?.user ?
@@ -140,7 +137,7 @@ export default function PostModal({
                 </div>
               : null}
 
-              <div className="flex flex-col flex-grow px-3 py-4 gap-3 overflow-y-auto border-b border-slate-300 dark:border-slate-600">
+              <div className="hidden sm:flex flex-col flex-grow px-3 py-4 gap-3 overflow-y-auto border-b border-slate-300 dark:border-slate-600">
                 <div className="flex flex-row gap-3">
                   <div className="size-8">
                     <ProfilePic photo={post?.user.profilePic} />

--- a/src/features/core/types/photo.ts
+++ b/src/features/core/types/photo.ts
@@ -4,6 +4,9 @@ type Photo = {
   _id: ObjectId;
   url: string;
   altText: string;
+  width: number;
+  height: number;
+  hwRatio: string;
 };
 
 export default Photo;


### PR DESCRIPTION
This PR changes how photos are displayed in `PostModal` component by using photo dimensions in styling. Unintended cropping has been removed from photos in portrait orientation and modal padding/max height has been changed in order to prevent overlaps between the modal itself and its close button.