### PR TITLE
feat: Add semantic tags to HTML markup

### DIFF
--- a/src/features/core/components/Footer.tsx
+++ b/src/features/core/components/Footer.tsx
@@ -2,13 +2,16 @@ import { Link } from "react-router-dom";
 import { format } from "date-fns";
 
 export default function Footer() {
+  const date = __BUILD_DATE__;
+  const title = format(date, "MMM dd, yyyy");
+
   return (
     <footer className="box-border hidden flex-row justify-center space-x-2 border-t border-slate-300 p-2 sm:flex dark:border-slate-600">
       <Link to="/about" className="hover:underline">
         About
       </Link>
       <span>{`v${import.meta.env.VITE_APP_VERSION}`}</span>
-      <span>{format(__BUILD_DATE__, "dd.MM.yyyy")}</span>
+      <time title={title}>{format(date, "dd.MM.yyyy")}</time>
     </footer>
   );
 }

--- a/src/features/core/components/Navbar.tsx
+++ b/src/features/core/components/Navbar.tsx
@@ -210,10 +210,10 @@ export default function Navbar() {
         <SearchUsers />
       </Drawer>
 
-      <nav
+      <header
         className={`z-10 h-12 shrink-0 sm:h-screen ${searchDrawerOpen ? "mr-44 w-fit" : "w-full sm:w-fit xl:w-64"} fixed bottom-0 overflow-y-auto border-r-0 border-t border-slate-300 bg-white sm:static sm:border-r sm:border-t-0 dark:border-slate-600 dark:bg-gray-900`}
       >
-        <div className="flex h-fit flex-row justify-evenly gap-0 sm:min-h-screen sm:flex-col sm:justify-normal sm:gap-6 sm:px-3 sm:pb-5 sm:pt-8">
+        <nav className="flex h-fit flex-row justify-evenly gap-0 sm:min-h-screen sm:flex-col sm:justify-normal sm:gap-6 sm:px-3 sm:pb-5 sm:pt-8">
           <NavLink
             to="/"
             className="hidden h-fit w-fit sm:flex sm:flex-row sm:items-start sm:justify-start xl:h-16"
@@ -228,11 +228,14 @@ export default function Navbar() {
                 <div
                   className={`group ${searchDrawerOpen ? "block" : "block xl:hidden"} group:text-gray-700 rounded-lg p-2 hover:bg-black/5 dark:hover:bg-white/10 dark:active:text-gray-400`}
                 >
-                  <NavIcon
-                    isActive={isActive}
-                    Icon={CameraIcon}
-                    ActiveIcon={CameraIcon}
-                  />
+                  <h1>
+                    <NavIcon
+                      isActive={isActive}
+                      Icon={CameraIcon}
+                      ActiveIcon={CameraIcon}
+                      title={import.meta.env.VITE_APP_TITLE}
+                    />
+                  </h1>
                 </div>
               </>
             )}
@@ -294,8 +297,8 @@ export default function Navbar() {
             menuItemsProps={{ anchor: "bottom start" }}
             items={menuItems}
           />
-        </div>
-      </nav>
+        </nav>
+      </header>
     </>
   );
 }

--- a/src/features/core/components/PostModal.tsx
+++ b/src/features/core/components/PostModal.tsx
@@ -125,7 +125,7 @@ export default function PostModal({
           <div className="flex h-full w-full shrink-0 flex-row border-l border-slate-300 sm:w-80 sm:basis-80 xl:w-[26rem] xl:basis-[26rem] dark:border-slate-600">
             <div className="flex grow flex-col">
               {isSmBreakpoint ?
-                <div className="flex w-full flex-row items-center justify-between border-b border-slate-300 px-3 py-2 dark:border-slate-600">
+                <header className="flex w-full flex-row items-center justify-between border-b border-slate-300 px-3 py-2 dark:border-slate-600">
                   {post?.user ?
                     <UserBar user={post.user} />
                   : null}
@@ -134,7 +134,7 @@ export default function PostModal({
                     Icon={EllipsisHorizontalIcon}
                     onClick={onPostMenuClick}
                   />
-                </div>
+                </header>
               : null}
 
               <div className="hidden flex-grow flex-col gap-3 overflow-y-auto border-b border-slate-300 px-3 py-4 sm:flex dark:border-slate-600">
@@ -162,7 +162,7 @@ export default function PostModal({
                 : null}
               </div>
 
-              <div className="flex flex-row justify-between px-3 py-2">
+              <section className="flex flex-row justify-between px-3 py-2">
                 <div className="flex flex-row items-center gap-2">
                   <IconButton
                     Icon={HeartIcon}
@@ -194,12 +194,12 @@ export default function PostModal({
                     onClick={onSaveClick}
                   />
                 </div>
-              </div>
+              </section>
 
-              <div className="flex flex-col border-b border-slate-300 px-3 pb-2 dark:border-slate-600">
+              <section className="flex flex-col border-b border-slate-300 px-3 pb-2 dark:border-slate-600">
                 <LikeCounter likes={post?.likes} hideLikes={post?.hideLikes} />
                 <Timestamp date={post?.createdAt} suffix />
-              </div>
+              </section>
 
               <div className="hidden px-3 py-2">New comment</div>
             </div>

--- a/src/features/core/components/Timestamp.tsx
+++ b/src/features/core/components/Timestamp.tsx
@@ -34,12 +34,13 @@ export default function Timestamp({
   return (
     <>
       {date ?
-        <div
+        <time
           title={title}
+          dateTime={date}
           className={`${fontSize} text-gray-800 dark:text-gray-400`}
         >
           {formatDistance(distance, suffix)}
-        </div>
+        </time>
       : null}
     </>
   );

--- a/src/features/explore/components/PostSquare.tsx
+++ b/src/features/explore/components/PostSquare.tsx
@@ -15,7 +15,7 @@ export default function PostSquare({ post, onClick }: PostSquareProps) {
   const multiplePhotos = post.photos.length > 1;
 
   return (
-    <div onClick={onClick} className="group relative cursor-pointer">
+    <article onClick={onClick} className="group relative cursor-pointer">
       <div className="relative h-full w-full pb-[100%]">
         <img
           src={previewPhoto.url}
@@ -43,6 +43,6 @@ export default function PostSquare({ post, onClick }: PostSquareProps) {
           </div>
         : null}
       </div>
-    </div>
+    </article>
   );
 }

--- a/src/features/feed/components/RecommendedUsers.tsx
+++ b/src/features/feed/components/RecommendedUsers.tsx
@@ -62,7 +62,7 @@ export default function RecommendedUsers() {
   };
 
   return (
-    <div className="flex flex-col gap-4">
+    <aside className="flex flex-col gap-4">
       <span className="text-sm font-semibold text-gray-500 dark:text-gray-400">
         Suggested for you
       </span>
@@ -94,6 +94,6 @@ export default function RecommendedUsers() {
           ))}
         </>
       : null}
-    </div>
+    </aside>
   );
 }

--- a/src/features/posts/components/PostPreview.tsx
+++ b/src/features/posts/components/PostPreview.tsx
@@ -81,7 +81,7 @@ export default function PostPreview({ post }: PostProps) {
         onDelete={onPostDelete}
       />
 
-      <div className="flex flex-col gap-2">
+      <article className="flex flex-col gap-2">
         <div className="flex flex-row items-center justify-between px-3 sm:px-0">
           <div className="flex flex-row items-center gap-1">
             <UserBar user={post?.user} followEnabled={false} />
@@ -108,7 +108,7 @@ export default function PostPreview({ post }: PostProps) {
         </div>
 
         <div className="flex flex-col gap-2 px-3 sm:px-0">
-          <div className="flex flex-row justify-between">
+          <section className="flex flex-row justify-between">
             <div className="flex flex-row items-center gap-2">
               <IconButton
                 Icon={HeartIcon}
@@ -140,18 +140,20 @@ export default function PostPreview({ post }: PostProps) {
                 onClick={onSaveClick}
               />
             </div>
-          </div>
-          <LikeCounter likes={post.likes} hideLikes={post.hideLikes} />
+          </section>
+          <section>
+            <LikeCounter likes={post.likes} hideLikes={post.hideLikes} />
+          </section>
           {post.caption?.length > 0 ?
-            <div>
+            <section>
               <span className="mr-1 inline font-semibold">
                 {post.user?.name || "user"}
               </span>
               <ShowMoreText text={post.caption} overflowLength={100} />
-            </div>
+            </section>
           : null}
         </div>
-      </div>
+      </article>
     </>
   );
 }

--- a/src/features/profiles/components/Profile.tsx
+++ b/src/features/profiles/components/Profile.tsx
@@ -81,7 +81,7 @@ export default function Profile({ initialData }: ProfileProps) {
 
             <section className="col-start-2 row-start-1">
               <div className="flex flex-row flex-wrap items-center justify-start gap-4 sm:justify-center">
-                <div className="text-xl">{user.name}</div>
+                <h2 className="text-xl">{user.name}</h2>
                 <div className="flex flex-row items-center gap-2">
                   {user._id !== currentUser?._id ?
                     <Button


### PR DESCRIPTION
* Added missing `<h1>` tags in navbar where application title/icon is visible.
* Individual photos in Explore and Feed have been changed to `<article> `
* Added `<section>` tags in post views to group related information.
* Added `<time>` tags in `Timestamp` component and in footer's build date.
* Changed `RecommendedUsers` to be an `<aside>` of main content in feed.