### PR TITLE
refactor: Format classNames using clsx and prettier-plugin-classnames

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -11,8 +11,15 @@
   "tabWidth": 2,
   "trailingComma": "all",
   "useTabs": false,
-  "plugins": ["prettier-plugin-tailwindcss"],
+  "plugins": [
+    "prettier-plugin-tailwindcss",
+    "prettier-plugin-classnames",
+    "prettier-plugin-merge"
+  ],
 
   "tailwindConfig": "./tailwind.config.ts",
-  "tailwindFunctions": ["clsx"]
+  "tailwindFunctions": ["clsx"],
+  "customAttributes": ["className"],
+  "customFunctions": ["clsx"],
+  "endingPosition": "relative"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -12,5 +12,7 @@
   "trailingComma": "all",
   "useTabs": false,
   "plugins": ["prettier-plugin-tailwindcss"],
-  "tailwindConfig": "./tailwind.config.ts"
+
+  "tailwindConfig": "./tailwind.config.ts",
+  "tailwindFunctions": ["clsx"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@hookform/resolvers": "^3.9.0",
         "@tanstack/react-query": "^5.51.23",
         "axios": "^1.7.3",
+        "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,8 @@
         "jsdom": "^24.1.1",
         "postcss": "^8.4.41",
         "prettier": "^3.3.3",
+        "prettier-plugin-classnames": "^0.7.3",
+        "prettier-plugin-merge": "^0.7.1",
         "prettier-plugin-tailwindcss": "^0.6.8",
         "tailwindcss": "^3.4.7",
         "typescript": "^5.2.2",
@@ -2704,6 +2706,15 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
+    },
+    "node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -5414,6 +5425,43 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-classnames": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-classnames/-/prettier-plugin-classnames-0.7.3.tgz",
+      "integrity": "sha512-pl7RENikiCq0FpjyO/7XayLV49VXPGyBkbPnEmEkaicGweOnO0GrUaCeo2GvqB/rzERGvBRurB6/yQPF70WPTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prettier-plugin-merge": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-merge/-/prettier-plugin-merge-0.7.1.tgz",
+      "integrity": "sha512-R3dSlv3kAlScjd/liWjTkGHcUrE4MBhPKKBxVOvHK7+FY2P5SEmLarZiD11VUEuaMRK0L7zqIurX6JcRYS9Y5Q==",
+      "dev": true,
+      "dependencies": {
+        "diff": "5.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "jsdom": "^24.1.1",
     "postcss": "^8.4.41",
     "prettier": "^3.3.3",
+    "prettier-plugin-classnames": "^0.7.3",
+    "prettier-plugin-merge": "^0.7.1",
     "prettier-plugin-tailwindcss": "^0.6.8",
     "tailwindcss": "^3.4.7",
     "typescript": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@hookform/resolvers": "^3.9.0",
     "@tanstack/react-query": "^5.51.23",
     "axios": "^1.7.3",
+    "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/features/accounts/components/LoginForm.tsx
+++ b/src/features/accounts/components/LoginForm.tsx
@@ -77,7 +77,8 @@ export default function LoginForm() {
           : null}
           <Button
             type="submit"
-            className="mt-4 w-full rounded-lg bg-blue-500 py-1 font-semibold text-white disabled:bg-blue-400"
+            className="mt-4 w-full rounded-lg bg-blue-500 py-1 font-semibold text-white
+              disabled:bg-blue-400"
           >
             Log in
           </Button>
@@ -97,7 +98,10 @@ export default function LoginForm() {
         </div>
       </div>
 
-      <div className="flex flex-row justify-center rounded border border-slate-300 py-4 dark:border-slate-600">
+      <div
+        className="flex flex-row justify-center rounded border border-slate-300 py-4
+          dark:border-slate-600"
+      >
         <p>
           {"Don't have an account? "}
           <Link to="/accounts/signup" className="text-blue-500">

--- a/src/features/accounts/components/RegisterForm.tsx
+++ b/src/features/accounts/components/RegisterForm.tsx
@@ -105,14 +105,18 @@ export default function RegisterForm() {
           : null}
           <button
             type="submit"
-            className="mt-4 w-full rounded-lg bg-blue-500 py-1 font-semibold text-white disabled:bg-blue-400"
+            className="mt-4 w-full rounded-lg bg-blue-500 py-1 font-semibold text-white
+              disabled:bg-blue-400"
           >
             Next
           </button>
         </form>
       </div>
 
-      <div className="flex flex-row justify-center rounded border border-slate-300 py-4 dark:border-slate-600">
+      <div
+        className="flex flex-row justify-center rounded border border-slate-300 py-4
+          dark:border-slate-600"
+      >
         <p>
           {"Have an account? "}
           <Link to="/accounts/login" className="text-blue-500">

--- a/src/features/core/components/Accordion.tsx
+++ b/src/features/core/components/Accordion.tsx
@@ -19,7 +19,10 @@ export default function Accordion({
 }: AccordionProps) {
   return (
     <Disclosure>
-      <DisclosureButton className="group flex flex-row items-center justify-between gap-2 text-start font-normal data-[open]:font-semibold">
+      <DisclosureButton
+        className="group flex flex-row items-center justify-between gap-2 text-start font-normal
+          data-[open]:font-semibold"
+      >
         {title}
         <ChevronDownIcon className="w-5 group-data-[open]:rotate-180" />
       </DisclosureButton>

--- a/src/features/core/components/Drawer.tsx
+++ b/src/features/core/components/Drawer.tsx
@@ -1,5 +1,6 @@
-import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
 import { ReactNode } from "react";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
+import clsx from "clsx";
 
 type DrawerProps = {
   isOpen: boolean;
@@ -25,11 +26,17 @@ export default function Drawer({
       <div className="fixed inset-0 overflow-hidden">
         <div className="absolute inset-0 overflow-hidden">
           <div
-            className={`fixed inset-y-0 flex max-w-full ${position ? position : "left-0"}`}
+            className={clsx(
+              "fixed inset-y-0 flex max-w-full",
+              position ? position : "left-0",
+            )}
           >
             <DialogPanel
               transition
-              className="sm:duration-400 pointer-events-auto relative w-screen max-w-64 translate-x-0 rounded-e-xl border-e border-slate-300 bg-white transition duration-300 ease-in-out data-[closed]:-translate-x-full sm:max-w-sm dark:border-slate-600 dark:bg-gray-900"
+              className={`sm:duration-400 pointer-events-auto relative w-screen max-w-64 translate-x-0
+                rounded-e-xl border-e border-slate-300 bg-white transition duration-300
+                ease-in-out data-[closed]:-translate-x-full sm:max-w-sm dark:border-slate-600
+                dark:bg-gray-900`}
             >
               <div className="flex h-full flex-col overflow-y-auto py-6 shadow-xl">
                 <div className="px-4 sm:px-6">

--- a/src/features/core/components/Dropdown.tsx
+++ b/src/features/core/components/Dropdown.tsx
@@ -42,9 +42,8 @@ export default function Dropdown({
         leaveTo="transform opacity-0 scale-95"
       >
         <MenuItems
-          className={
-            "absolute z-10 flex w-64 flex-col space-y-2 rounded-xl bg-white p-2 shadow-xl [--anchor-gap:4px] dark:bg-gray-800"
-          }
+          className={`absolute z-10 flex w-64 flex-col space-y-2 rounded-xl bg-white p-2 shadow-xl
+            [--anchor-gap:4px] dark:bg-gray-800`}
           {...menuItemsProps}
         >
           {items.map((item) => (

--- a/src/features/core/components/Footer.tsx
+++ b/src/features/core/components/Footer.tsx
@@ -6,7 +6,10 @@ export default function Footer() {
   const title = format(date, "MMM dd, yyyy");
 
   return (
-    <footer className="box-border hidden flex-row justify-center space-x-2 border-t border-slate-300 p-2 sm:flex dark:border-slate-600">
+    <footer
+      className="box-border hidden flex-row justify-center space-x-2 border-t border-slate-300
+        p-2 sm:flex dark:border-slate-600"
+    >
       <Link to="/about" className="hover:underline">
         About
       </Link>

--- a/src/features/core/components/IconButton.tsx
+++ b/src/features/core/components/IconButton.tsx
@@ -31,7 +31,9 @@ export default function IconButton({
   };
   return (
     <Button
-      className="text-gray-900 hover:text-gray-700 active:text-gray-700 disabled:text-gray-400 dark:text-gray-200 dark:hover:text-gray-400 dark:active:text-gray-500 disabled:dark:text-gray-600"
+      className={`text-gray-900 hover:text-gray-700 active:text-gray-700 disabled:text-gray-400
+        dark:text-gray-200 dark:hover:text-gray-400 dark:active:text-gray-500
+        dark:disabled:text-gray-600`}
       {...rest}
     >
       {getIcon(Icon, SolidIcon, solid)}

--- a/src/features/core/components/Input.tsx
+++ b/src/features/core/components/Input.tsx
@@ -13,22 +13,31 @@ export default function Input({
   const ValidationMarkComponent = error ? XCircleIcon : CheckCircleIcon;
 
   return (
-    <div className="group relative flex w-full flex-row items-center rounded-md border border-gray-300 has-[:focus]:border-gray-600 dark:border-gray-600 has-[:focus]:dark:border-gray-500">
+    <div
+      className={`group relative flex w-full flex-row items-center rounded-md border
+        border-gray-300 has-[:focus]:border-gray-600 dark:border-gray-600
+        has-[:focus]:dark:border-gray-500`}
+    >
       <HeadlessInput
         id={name}
         {...(register && register(name))}
-        className="peer w-full text-ellipsis bg-inherit px-2.5 pb-2 pt-[15px] text-sm text-inherit ring-0 ring-inset focus:outline-none focus:ring-0"
+        className="peer w-full text-ellipsis bg-inherit px-2.5 pb-2 pt-[15px] text-sm text-inherit
+          ring-0 ring-inset focus:outline-none focus:ring-0"
         placeholder=""
         {...rest}
       />
       <label
         htmlFor={name}
-        className="absolute start-[11px] top-4 z-10 origin-[0] -translate-y-4 scale-75 transform text-sm text-gray-500 duration-300 peer-placeholder-shown:translate-y-0 peer-placeholder-shown:scale-100 peer-focus:text-gray-600 dark:text-gray-500 peer-focus:dark:text-gray-400"
+        className={`absolute start-[11px] top-4 z-10 origin-[0] -translate-y-4 scale-75 transform
+          text-sm text-gray-500 duration-300 peer-placeholder-shown:translate-y-0
+          peer-placeholder-shown:scale-100 peer-focus:text-gray-600 dark:text-gray-500
+          peer-focus:dark:text-gray-400`}
       >
         {label}
       </label>
       <ValidationMarkComponent
-        className={`end-2 top-2.5 mx-2 block size-6 text-gray-400 peer-placeholder-shown:hidden peer-focus:hidden peer-aria-[invalid="true"]:text-red-600`}
+        className={`end-2 top-2.5 mx-2 block size-6 text-gray-400 peer-placeholder-shown:hidden
+          peer-focus:hidden peer-aria-[invalid="true"]:text-red-600`}
       />
     </div>
   );

--- a/src/features/core/components/Modal.tsx
+++ b/src/features/core/components/Modal.tsx
@@ -42,7 +42,11 @@ export default function Modal({
         >
           <XMarkIcon className="size-7 stroke-2 font-bold text-black dark:text-white" />
         </Button>
-        <DialogPanel className="w-full max-w-full overflow-hidden rounded-xl bg-white shadow-xl duration-150 ease-out data-[closed]:scale-95 data-[closed]:opacity-0 sm:max-w-fit dark:bg-gray-800">
+        <DialogPanel
+          className={`w-full max-w-full overflow-hidden rounded-xl bg-white shadow-xl duration-150
+            ease-out data-[closed]:scale-95 data-[closed]:opacity-0 sm:max-w-fit
+            dark:bg-gray-800`}
+        >
           {title ? title : null}
           <div className="h-full w-full">{children}</div>
         </DialogPanel>

--- a/src/features/core/components/NavIcon.tsx
+++ b/src/features/core/components/NavIcon.tsx
@@ -13,8 +13,9 @@ type NavIconProps = {
   title?: string;
 };
 
-const iconStyle =
-  "size-8 text-gray-900 dark:text-gray-200 transition duration-75 group-active:scale-90 group-active:text-gray-700 dark:group-active:text-gray-400 group-hover:scale-105";
+const iconStyle = `size-8 text-gray-900 transition duration-75 group-hover:scale-105
+  group-active:scale-90 group-active:text-gray-700 dark:text-gray-200
+  dark:group-active:text-gray-400`;
 
 export default function NavIcon({
   isActive = false,

--- a/src/features/core/components/Navbar.tsx
+++ b/src/features/core/components/Navbar.tsx
@@ -33,6 +33,7 @@ import SiteLogo from "./SiteLogo";
 import { Button } from "@headlessui/react";
 import SearchUsers from "./SearchUsers";
 import Drawer from "./Drawer";
+import clsx from "clsx";
 
 type NavbarElement = {
   key: string;
@@ -52,12 +53,14 @@ type NavbarButton = NavbarElement & {
 };
 type NavbarItem = NavbarLink | NavbarButton;
 
-const navButtonStyle =
-  "group xl:w-full block xl:inline-flex xl:items-center xl:gap-4 p-2 rounded-none sm:rounded-lg text-base hover:bg-black/5 dark:hover:bg-white/10 group:text-gray-700 dark:active:text-gray-400";
-const menuButtonStyle =
-  "group w-full inline-flex items-center gap-2 p-2 rounded-none sm:rounded-lg text-sm hover:bg-black/5 dark:hover:bg-white/10 text-gray-900 dark:text-gray-200 active:text-gray-700 dark:active:text-gray-400";
-const menuIconStyle =
-  "size-5 text-gray-900 dark:text-gray-200 group-active:text-gray-700 dark:group-active:text-gray-400";
+const navButtonStyle = `group block rounded-none p-2 text-base sm:rounded-lg xl:inline-flex xl:w-full
+  xl:items-center xl:gap-4 group:text-gray-700 hover:bg-black/5 dark:hover:bg-white/10
+  dark:active:text-gray-400`;
+const menuButtonStyle = `group inline-flex w-full items-center gap-2 rounded-none p-2 text-sm
+  sm:rounded-lg text-gray-900 hover:bg-black/5 active:text-gray-700 dark:text-gray-200
+  dark:hover:bg-white/10 dark:active:text-gray-400`;
+const menuIconStyle = `size-5 text-gray-900 group-active:text-gray-700 dark:text-gray-200
+  dark:group-active:text-gray-400`;
 
 export default function Navbar() {
   const navigate = useNavigate();
@@ -211,9 +214,17 @@ export default function Navbar() {
       </Drawer>
 
       <header
-        className={`z-10 h-12 shrink-0 sm:h-screen ${searchDrawerOpen ? "mr-44 w-fit" : "w-full sm:w-fit xl:w-64"} fixed bottom-0 overflow-y-auto border-r-0 border-t border-slate-300 bg-white sm:static sm:border-r sm:border-t-0 dark:border-slate-600 dark:bg-gray-900`}
+        className={clsx(
+          `fixed bottom-0 z-10 h-12 shrink-0 overflow-y-auto border-r-0 border-t
+          border-slate-300 bg-white sm:static sm:h-screen sm:border-r sm:border-t-0
+          dark:border-slate-600 dark:bg-gray-900`,
+          searchDrawerOpen ? "mr-44 w-fit" : "w-full sm:w-fit xl:w-64",
+        )}
       >
-        <nav className="flex h-fit flex-row justify-evenly gap-0 sm:min-h-screen sm:flex-col sm:justify-normal sm:gap-6 sm:px-3 sm:pb-5 sm:pt-8">
+        <nav
+          className="flex h-fit flex-row justify-evenly gap-0 sm:min-h-screen sm:flex-col
+            sm:justify-normal sm:gap-6 sm:px-3 sm:pb-5 sm:pt-8"
+        >
           <NavLink
             to="/"
             className="hidden h-fit w-fit sm:flex sm:flex-row sm:items-start sm:justify-start xl:h-16"
@@ -221,12 +232,19 @@ export default function Navbar() {
             {({ isActive }) => (
               <>
                 <div
-                  className={`${searchDrawerOpen ? "hidden" : "hidden xl:block"} ml-2`}
+                  className={clsx(
+                    "ml-2",
+                    searchDrawerOpen ? "hidden" : "hidden xl:block",
+                  )}
                 >
                   <SiteLogo />
                 </div>
                 <div
-                  className={`group ${searchDrawerOpen ? "block" : "block xl:hidden"} group:text-gray-700 rounded-lg p-2 hover:bg-black/5 dark:hover:bg-white/10 dark:active:text-gray-400`}
+                  className={clsx(
+                    `group:text-gray-700 group rounded-lg p-2 hover:bg-black/5 dark:hover:bg-white/10
+                    dark:active:text-gray-400`,
+                    searchDrawerOpen ? "block" : "block xl:hidden",
+                  )}
                 >
                   <h1>
                     <NavIcon
@@ -255,7 +273,10 @@ export default function Navbar() {
                             ActiveIcon={item.iconActive}
                           />
                           <div
-                            className={`${searchDrawerOpen ? "hidden" : "hidden xl:block"} ${isActive ? "font-semibold" : "font-normal"}`}
+                            className={clsx(
+                              isActive ? "font-semibold" : "font-normal",
+                              searchDrawerOpen ? "hidden" : "hidden xl:block",
+                            )}
                           >
                             {item.label}
                           </div>
@@ -271,7 +292,10 @@ export default function Navbar() {
                       ActiveIcon={item.iconActive}
                     />
                     <div
-                      className={`${searchDrawerOpen ? "hidden" : "hidden xl:block"} font-normal`}
+                      className={clsx(
+                        "font-normal",
+                        searchDrawerOpen ? "hidden" : "hidden xl:block",
+                      )}
                     >
                       {item.label}
                     </div>
@@ -283,12 +307,24 @@ export default function Navbar() {
           <div className="hidden grow sm:block" />
           <Dropdown
             buttonChildren={({ active }: { active: boolean }) => (
-              <div className="inline-flex w-full items-center gap-4 rounded-none p-2 hover:bg-black/5 sm:rounded dark:hover:bg-white/10">
+              <div
+                className="inline-flex w-full items-center gap-4 rounded-none p-2 hover:bg-black/5
+                  sm:rounded dark:hover:bg-white/10"
+              >
                 <Bars3Icon
-                  className={`size-8 text-gray-900 transition duration-75 group-hover:scale-105 group-active:scale-90 group-active:text-gray-700 dark:text-gray-200 dark:group-active:text-gray-400 ${active ? "stroke-2" : null} `}
+                  className={clsx(
+                    `size-8 text-gray-900 transition duration-75 group-hover:scale-105
+                    group-active:scale-90 group-active:text-gray-700 dark:text-gray-200
+                    dark:group-active:text-gray-400`,
+                    active && "stroke-2",
+                  )}
                 />
                 <div
-                  className={`${searchDrawerOpen ? "hidden" : "hidden xl:block"} ${active ? "font-semibold" : "font-normal"} group-active:text-gray-700 dark:group-active:text-gray-400`}
+                  className={clsx(
+                    "group-active:text-gray-700 dark:group-active:text-gray-400",
+                    searchDrawerOpen ? "hidden" : "hidden xl:block",
+                    active ? "font-semibold" : "font-normal",
+                  )}
                 >
                   More
                 </div>

--- a/src/features/core/components/NavbarWrapper.tsx
+++ b/src/features/core/components/NavbarWrapper.tsx
@@ -6,7 +6,10 @@ export default function NavbarWrapper() {
   return (
     <div className="flex min-h-screen">
       <Navbar />
-      <section className="flex max-h-screen min-h-full w-full flex-col overflow-y-auto xl:w-[calc(100%-240px)]">
+      <section
+        className="flex max-h-screen min-h-full w-full flex-col overflow-y-auto
+          xl:w-[calc(100%-240px)]"
+      >
         <main className="grow pb-14 sm:pb-2">
           <Outlet />
         </main>

--- a/src/features/core/components/PhotoSlide.tsx
+++ b/src/features/core/components/PhotoSlide.tsx
@@ -3,6 +3,7 @@ import Photo from "../types/photo";
 import { Button } from "@headlessui/react";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 import useBreakpoint from "../hooks/useBreakpoint";
+import clsx from "clsx";
 
 type PhotoSlideProps = {
   photos: Photo[];
@@ -76,7 +77,10 @@ export default function PhotoSlide({ photos }: PhotoSlideProps) {
             {[...Array(photos.length).keys()].map((item) => (
               <div
                 key={item}
-                className={`size-1.5 rounded-full transition ${item === currentPhotoIndex ? "bg-gray-200" : "bg-gray-400"}`}
+                className={clsx(
+                  "size-1.5 rounded-full transition",
+                  item === currentPhotoIndex ? "bg-gray-200" : "bg-gray-400",
+                )}
               />
             ))}
           </div>

--- a/src/features/core/components/PopoverMenu.tsx
+++ b/src/features/core/components/PopoverMenu.tsx
@@ -33,7 +33,8 @@ export default function PopoverMenu({
       >
         <PopoverPanel
           anchor={anchor}
-          className="flex flex-col rounded-xl bg-white shadow-lg [--anchor-gap:4px] dark:bg-gray-800/90"
+          className="flex flex-col rounded-xl bg-white shadow-lg [--anchor-gap:4px]
+            dark:bg-gray-800/90"
         >
           {children}
         </PopoverPanel>

--- a/src/features/core/components/PostMenu.tsx
+++ b/src/features/core/components/PostMenu.tsx
@@ -41,7 +41,8 @@ export default function PostMenu({
             <Button
               autoFocus
               onClick={() => deleteMutation.mutate(post._id)}
-              className="w-full border-t border-slate-300 py-3 font-semibold text-red-500 dark:border-slate-600"
+              className="w-full border-t border-slate-300 py-3 font-semibold text-red-500
+                dark:border-slate-600"
             >
               Remove post
             </Button>

--- a/src/features/core/components/PostModal.tsx
+++ b/src/features/core/components/PostModal.tsx
@@ -106,9 +106,16 @@ export default function PostModal({
       />
 
       <Modal isOpen={isOpen} onClose={onClose}>
-        <div className="flex max-h-[calc(100vh-theme(space.10))] w-full flex-col items-center justify-center rounded-b-xl transition sm:h-[calc(100vh-theme(space.10))] sm:flex-row lg:max-w-[80rem] xl:max-w-[92rem]">
+        <div
+          className={`flex max-h-[calc(100vh-theme(space.10))] w-full flex-col items-center
+            justify-center rounded-b-xl transition sm:h-[calc(100vh-theme(space.10))]
+            sm:flex-row lg:max-w-[80rem] xl:max-w-[92rem]`}
+        >
           {!isSmBreakpoint ?
-            <div className="flex w-full flex-row items-center justify-between border-b border-slate-300 px-3 py-2 dark:border-slate-600">
+            <div
+              className="flex w-full flex-row items-center justify-between border-b border-slate-300 px-3
+                py-2 dark:border-slate-600"
+            >
               {post?.user ?
                 <UserBar user={post.user} />
               : null}
@@ -122,10 +129,16 @@ export default function PostModal({
 
           <PhotoSlide photos={photos} />
 
-          <div className="flex h-full w-full shrink-0 flex-row border-l border-slate-300 sm:w-80 sm:basis-80 xl:w-[26rem] xl:basis-[26rem] dark:border-slate-600">
+          <div
+            className="flex h-full w-full shrink-0 flex-row border-l border-slate-300 sm:w-80
+              sm:basis-80 xl:w-[26rem] xl:basis-[26rem] dark:border-slate-600"
+          >
             <div className="flex grow flex-col">
               {isSmBreakpoint ?
-                <header className="flex w-full flex-row items-center justify-between border-b border-slate-300 px-3 py-2 dark:border-slate-600">
+                <header
+                  className="flex w-full flex-row items-center justify-between border-b border-slate-300 px-3
+                    py-2 dark:border-slate-600"
+                >
                   {post?.user ?
                     <UserBar user={post.user} />
                   : null}
@@ -137,7 +150,10 @@ export default function PostModal({
                 </header>
               : null}
 
-              <div className="hidden flex-grow flex-col gap-3 overflow-y-auto border-b border-slate-300 px-3 py-4 sm:flex dark:border-slate-600">
+              <div
+                className="hidden flex-grow flex-col gap-3 overflow-y-auto border-b border-slate-300 px-3
+                  py-4 sm:flex dark:border-slate-600"
+              >
                 <div className="flex flex-row gap-3">
                   <div className="size-8">
                     <ProfilePic photo={post?.user.profilePic} />

--- a/src/features/core/components/SearchUsers.tsx
+++ b/src/features/core/components/SearchUsers.tsx
@@ -20,12 +20,18 @@ export default function SearchUsers() {
   return (
     <section className="flex flex-col gap-8">
       <div className="px-4 sm:px-6">
-        <div className="group relative flex w-full flex-row items-center rounded-md border border-gray-300 has-[:focus]:border-gray-600 dark:border-gray-600 has-[:focus]:dark:border-gray-500">
+        <div
+          className="group relative flex w-full flex-row items-center rounded-md border
+            border-gray-300 has-[:focus]:border-gray-600 dark:border-gray-600
+            has-[:focus]:dark:border-gray-500"
+        >
           <Input
             id={"search"}
             value={inputValue}
             onChange={(event) => setInputValue(event.target.value)}
-            className="peer mr-6 w-full text-ellipsis bg-inherit py-2 pl-10 pr-2.5 text-sm text-gray-800 text-inherit ring-0 ring-inset focus:pl-2.5 focus:text-gray-900 focus:outline-none focus:ring-0 dark:text-gray-400 focus:dark:text-gray-200"
+            className="peer mr-6 w-full text-ellipsis bg-inherit py-2 pl-10 pr-2.5 text-sm
+              text-gray-800 text-inherit ring-0 ring-inset focus:pl-2.5 focus:text-gray-900
+              focus:outline-none focus:ring-0 dark:text-gray-400 focus:dark:text-gray-200"
             placeholder="Search"
           />
           <label htmlFor={"search"} className="sr-only">
@@ -34,7 +40,8 @@ export default function SearchUsers() {
           <MagnifyingGlassIcon className="absolute start-2 block size-6 text-gray-400 peer-focus:hidden" />
           <Button
             onClick={clearInput}
-            className="absolute end-0 block p-2 peer-placeholder-shown:hidden peer-focus:block peer-placeholder-shown:peer-focus:hidden"
+            className="absolute end-0 block p-2 peer-placeholder-shown:hidden peer-focus:block
+              peer-placeholder-shown:peer-focus:hidden"
           >
             <XCircleIcon className="size-5 focus:text-gray-900 focus:dark:text-gray-200" />
           </Button>
@@ -48,7 +55,8 @@ export default function SearchUsers() {
               <NavLink
                 key={user._id}
                 to={`/${user.name}`}
-                className="flex w-full flex-row items-center gap-2 px-4 py-2 hover:bg-gray-200 sm:px-6 dark:hover:bg-gray-800"
+                className="flex w-full flex-row items-center gap-2 px-4 py-2 hover:bg-gray-200 sm:px-6
+                  dark:hover:bg-gray-800"
               >
                 <div className="size-10">
                   <ProfilePic photo={user.profilePic} />

--- a/src/features/core/components/Spinner.tsx
+++ b/src/features/core/components/Spinner.tsx
@@ -22,7 +22,8 @@ export default function Spinner({ size = "md" }: SpinnerProps) {
     <div role="status">
       <svg
         aria-hidden="true"
-        className={`${getSizeClass(size)} fill-blue-600 text-gray-200 motion-safe:animate-spin dark:text-gray-600`}
+        className={`${getSizeClass(size)} fill-blue-600 text-gray-200 motion-safe:animate-spin
+          dark:text-gray-600`}
         viewBox="0 0 100 101"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/src/features/core/components/Switch.tsx
+++ b/src/features/core/components/Switch.tsx
@@ -13,9 +13,14 @@ export default function Switch({ checked, onClick, onChange }: SwitchProps) {
       checked={checked}
       onClick={onClick}
       onChange={onChange}
-      className="group inline-flex h-6 w-10 flex-shrink-0 items-center rounded-full bg-gray-300 transition data-[checked]:bg-gray-500 dark:bg-gray-600 dark:data-[checked]:bg-gray-200"
+      className="group inline-flex h-6 w-10 flex-shrink-0 items-center rounded-full bg-gray-300
+        transition data-[checked]:bg-gray-500 dark:bg-gray-600
+        dark:data-[checked]:bg-gray-200"
     >
-      <span className="size-5 translate-x-0.5 rounded-full bg-white transition group-data-[checked]:translate-x-[1.125rem] dark:bg-gray-900" />
+      <span
+        className="size-5 translate-x-0.5 rounded-full bg-white transition
+          group-data-[checked]:translate-x-[1.125rem] dark:bg-gray-900"
+      />
     </HeadlessSwitch>
   );
 }

--- a/src/features/explore/components/Explore.tsx
+++ b/src/features/explore/components/Explore.tsx
@@ -5,6 +5,7 @@ import PostSquare from "./PostSquare";
 import PostModal from "../../core/components/PostModal";
 import Post from "../../core/types/post";
 import Spinner from "../../core/components/Spinner";
+import clsx from "clsx";
 
 export default function Explore() {
   const { data: allPosts, isLoading: postsLoading } = useAllPostsQuery();
@@ -54,7 +55,9 @@ export default function Explore() {
             <NavLink to="" end className="py-2">
               {({ isActive }) => (
                 <span
-                  className={`${isActive ? "" : "text-gray-400 dark:text-gray-700"}`}
+                  className={clsx(
+                    isActive ? "" : "text-gray-400 dark:text-gray-700",
+                  )}
                 >
                   Not personalized
                 </span>

--- a/src/features/explore/components/PostSquare.tsx
+++ b/src/features/explore/components/PostSquare.tsx
@@ -24,11 +24,16 @@ export default function PostSquare({ post, onClick }: PostSquareProps) {
         />
       </div>
       {multiplePhotos ?
-        <Square2StackIcon className="absolute right-2 top-2 size-6 scale-x-[-1] scale-y-[-1] rounded-full text-gray-200 drop-shadow-lg" />
+        <Square2StackIcon
+          className="absolute right-2 top-2 size-6 scale-x-[-1] scale-y-[-1] rounded-full
+            text-gray-200 drop-shadow-lg"
+        />
       : null}
 
       <div
-        className={`invisible absolute inset-0 flex flex-col items-center justify-center gap-0 font-bold text-gray-200 group-hover:visible group-hover:bg-black/25 md:flex-row md:gap-4`}
+        className={`invisible absolute inset-0 flex flex-col items-center justify-center gap-0
+          font-bold text-gray-200 group-hover:visible group-hover:bg-black/25 md:flex-row
+          md:gap-4`}
       >
         {!post.hideLikes ?
           <div className="inline-block">

--- a/src/features/feed/components/Feed.tsx
+++ b/src/features/feed/components/Feed.tsx
@@ -7,6 +7,7 @@ import ProfilePic from "../../core/components/ProfilePic";
 import useCurrentUserQuery from "../../core/hooks/useCurrentUserQuery";
 import useFollowingPostsQuery from "../hooks/useFollowingPostsQuery";
 import useForYouPostsQuery from "../hooks/useForYouPostsQuery";
+import clsx from "clsx";
 
 export default function Feed() {
   const navigate = useNavigate();
@@ -26,12 +27,22 @@ export default function Feed() {
 
   return (
     <div className="flex flex-row justify-center pt-4 sm:mt-8">
-      <div className="mx-0 w-full max-w-fit flex-grow overflow-auto sm:mx-4 md:mx-8 md:w-[32rem] lg:max-w-[46rem] xl:mx-16">
-        <div className="flex w-full max-w-2xl flex-row items-center justify-start gap-3 border-b border-slate-300 px-2 font-bold sm:px-0 dark:border-slate-600">
+      <div
+        className="mx-0 w-full max-w-fit flex-grow overflow-auto sm:mx-4 md:mx-8 md:w-[32rem]
+          lg:max-w-[46rem] xl:mx-16"
+      >
+        <div
+          className="flex w-full max-w-2xl flex-row items-center justify-start gap-3 border-b
+            border-slate-300 px-2 font-bold sm:px-0 dark:border-slate-600"
+        >
           <NavLink to="?variant=for-you" end className="py-2">
             {({ isActive }) => (
               <span
-                className={`${isActive && pageVariant === "for-you" ? "" : "text-gray-400 dark:text-gray-700"}`}
+                className={clsx(
+                  isActive && pageVariant === "for-you" ?
+                    ""
+                  : "text-gray-400 dark:text-gray-700",
+                )}
               >
                 For you
               </span>
@@ -40,7 +51,11 @@ export default function Feed() {
           <NavLink to="?variant=following" end className="py-2">
             {({ isActive }) => (
               <span
-                className={`${isActive && pageVariant === "following" ? "" : "text-gray-400 dark:text-gray-700"}`}
+                className={clsx(
+                  isActive && pageVariant === "following" ?
+                    ""
+                  : "text-gray-400 dark:text-gray-700",
+                )}
               >
                 Following
               </span>

--- a/src/features/landing/components/Home.tsx
+++ b/src/features/landing/components/Home.tsx
@@ -3,16 +3,22 @@ import LoginForm from "../../accounts/components/LoginForm";
 
 export default function Home() {
   return (
-    <div className="mx-auto flex h-full w-full max-w-screen-2xl flex-row items-center justify-center gap-4 px-8 md:gap-8 lg:gap-16">
+    <div
+      className="mx-auto flex h-full w-full max-w-screen-2xl flex-row items-center justify-center
+        gap-4 px-8 md:gap-8 lg:gap-16"
+    >
       <div className="relative hidden grow px-4 md:block">
         <div className="relative">
           <img
             src="https://res.cloudinary.com/potoh/image/upload/v1727970843/assets/gobtdiwptpzsshovoj1u.jpg"
-            className="relative z-20 max-w-[60%] -rotate-12 rounded-xl border border-slate-300 bg-white p-3 drop-shadow-lg dark:border-slate-600 dark:bg-gray-700"
+            className="relative z-20 max-w-[60%] -rotate-12 rounded-xl border border-slate-300 bg-white
+              p-3 drop-shadow-lg dark:border-slate-600 dark:bg-gray-700"
           />
           <img
             src="https://res.cloudinary.com/potoh/image/upload/v1727970841/assets/el9xavcvycwwzpagqyqk.jpg"
-            className="absolute left-[40%] top-0 max-w-[60%] rotate-12 rounded-xl border border-slate-300 bg-white p-3 drop-shadow-lg dark:border-slate-600 dark:bg-gray-700"
+            className="absolute left-[40%] top-0 max-w-[60%] rotate-12 rounded-xl border
+              border-slate-300 bg-white p-3 drop-shadow-lg dark:border-slate-600
+              dark:bg-gray-700"
           />
         </div>
 

--- a/src/features/photo/components/PhotoDropArea.tsx
+++ b/src/features/photo/components/PhotoDropArea.tsx
@@ -49,7 +49,8 @@ export default function PhotoDropArea({
       <div className="relative w-fit">
         <label
           htmlFor="post_photo_input"
-          className="cursor-pointer select-none rounded-xl bg-blue-500 px-6 py-1.5 text-lg font-semibold text-white hover:bg-blue-600 disabled:bg-blue-400"
+          className="cursor-pointer select-none rounded-xl bg-blue-500 px-6 py-1.5 text-lg
+            font-semibold text-white hover:bg-blue-600 disabled:bg-blue-400"
         >
           {!dropError ? "Select from computer" : "Select other files"}
         </label>

--- a/src/features/photo/components/PhotoEdit.tsx
+++ b/src/features/photo/components/PhotoEdit.tsx
@@ -64,7 +64,10 @@ export default function PhotoEdit({ files, stage }: PhotoEditProps) {
           />
 
           {stage === "crop" ?
-            <div className="absolute bottom-0 mb-3 flex w-full flex-row items-center justify-between gap-4 px-4">
+            <div
+              className="absolute bottom-0 mb-3 flex w-full flex-row items-center justify-between gap-4
+                px-4"
+            >
               <div className="flex flex-row gap-4">
                 <PopoverMenu
                   anchor={"bottom start"}
@@ -129,7 +132,10 @@ export default function PhotoEdit({ files, stage }: PhotoEditProps) {
             </Button>
           : null}
           {fileArray.length > 1 ?
-            <div className="absolute bottom-0 mb-3 inline-flex w-full flex-row items-center justify-center gap-2">
+            <div
+              className="absolute bottom-0 mb-3 inline-flex w-full flex-row items-center justify-center
+                gap-2"
+            >
               {fileArray.map((item, idx) => (
                 <div
                   key={item.key}
@@ -144,7 +150,10 @@ export default function PhotoEdit({ files, stage }: PhotoEditProps) {
       {stage === "share" ?
         <ConnectForm>
           {({ control, register, watch }) => (
-            <div className="flex w-fit min-w-[12rem] basis-full flex-col gap-4 overflow-y-auto sm:basis-1/2 md:basis-1/3">
+            <div
+              className="flex w-fit min-w-[12rem] basis-full flex-col gap-4 overflow-y-auto sm:basis-1/2
+                md:basis-1/3"
+            >
               <div className="flex flex-row items-center gap-2 px-4 pt-4">
                 <div className="size-8">
                   <ProfilePic photo={currentUser?.profilePic} />

--- a/src/features/photo/components/PhotoUpload.tsx
+++ b/src/features/photo/components/PhotoUpload.tsx
@@ -18,6 +18,7 @@ import { useMutation } from "@tanstack/react-query";
 import { postPost } from "../api/queries";
 import Spinner from "../../core/components/Spinner";
 import { zodResolver } from "@hookform/resolvers/zod";
+import clsx from "clsx";
 
 type PhotoUploadProps = {
   isOpen: boolean;
@@ -186,7 +187,10 @@ export default function PhotoUpload({ isOpen, setIsOpen }: PhotoUploadProps) {
             onClose={onClose}
             getRootProps={getRootProps}
             title={
-              <DialogTitle className="inline-flex w-full flex-row items-center justify-between border-b border-gray-100 px-3 py-1 text-center text-lg font-semibold dark:border-gray-900">
+              <DialogTitle
+                className="inline-flex w-full flex-row items-center justify-between border-b
+                  border-gray-100 px-3 py-1 text-center text-lg font-semibold dark:border-gray-900"
+              >
                 {stage === "crop" || stage === "share" ?
                   <Button onClick={() => handlePrevious(stage)}>
                     <ArrowLeftIcon className="size-6 dark:text-white" />
@@ -205,7 +209,11 @@ export default function PhotoUpload({ isOpen, setIsOpen }: PhotoUploadProps) {
             }
           >
             <div
-              className={`flex h-[30rem] w-full flex-col items-center justify-center rounded-b-xl transition ${isDragActive ? "bg-black/5 dark:bg-black/50" : ""}`}
+              className={clsx(
+                `flex h-[30rem] w-full flex-col items-center justify-center rounded-b-xl
+                transition`,
+                isDragActive ? "bg-black/5 dark:bg-black/50" : "",
+              )}
             >
               {stage === "dragAndDrop" || stage === "error" ?
                 <PhotoDropArea
@@ -246,7 +254,8 @@ export default function PhotoUpload({ isOpen, setIsOpen }: PhotoUploadProps) {
             <Button
               autoFocus
               onClick={onDiscard}
-              className="w-full border-t border-slate-300 py-3 font-semibold text-red-500 dark:border-slate-600"
+              className="w-full border-t border-slate-300 py-3 font-semibold text-red-500
+                dark:border-slate-600"
             >
               Discard
             </Button>

--- a/src/features/profiles/components/Profile.tsx
+++ b/src/features/profiles/components/Profile.tsx
@@ -18,6 +18,7 @@ import useUnfollowMutation from "../../core/hooks/useUnfollowMutation";
 import ProfilePic from "../../core/components/ProfilePic";
 import ProfilePicInput from "./ProfilePicInput";
 import useUsersByUsernameQuery from "../../core/hooks/useUsersByUsernameQuery";
+import clsx from "clsx";
 
 type ProfileProps = {
   initialData: {
@@ -69,7 +70,10 @@ export default function Profile({ initialData }: ProfileProps) {
     <div className="w-full pt-12">
       <div className="mx-auto max-w-full md:max-w-5xl xl:max-w-5xl">
         <div className="flex flex-col gap-4 px-0 md:px-6">
-          <header className="mx-4 grid grid-cols-[76px_4fr] items-start justify-items-start gap-4 sm:grid-cols-[120px_4fr] md:grid-cols-[1fr_2fr]">
+          <header
+            className="mx-4 grid grid-cols-[76px_4fr] items-start justify-items-start gap-4
+              sm:grid-cols-[120px_4fr] md:grid-cols-[1fr_2fr]"
+          >
             <section className="row-start-1 mr-2 sm:row-end-4 md:row-end-5 md:mr-6 md:justify-self-center">
               <div className="relative size-16 sm:size-24 md:size-40">
                 <ProfilePic photo={user?.profilePic} />
@@ -86,7 +90,8 @@ export default function Profile({ initialData }: ProfileProps) {
                   {user._id !== currentUser?._id ?
                     <Button
                       onClick={onFollowClick}
-                      className="rounded-lg bg-gray-300 px-4 py-1 font-semibold hover:bg-gray-400 dark:bg-gray-700 dark:hover:bg-gray-800"
+                      className="rounded-lg bg-gray-300 px-4 py-1 font-semibold hover:bg-gray-400
+                        dark:bg-gray-700 dark:hover:bg-gray-800"
                     >
                       {follow ? "Following" : "Follow"}
                     </Button>
@@ -112,7 +117,10 @@ export default function Profile({ initialData }: ProfileProps) {
               </div>
             </section>
 
-            <section className="col-start-1 col-end-3 row-start-3 row-end-4 whitespace-pre-line leading-none sm:row-start-4 md:col-start-2 md:col-end-2 md:row-start-3 md:row-end-3">
+            <section
+              className="col-start-1 col-end-3 row-start-3 row-end-4 whitespace-pre-line leading-none
+                sm:row-start-4 md:col-start-2 md:col-end-2 md:row-start-3 md:row-end-3"
+            >
               <div>
                 <ShowMoreText
                   text={user.description}
@@ -134,11 +142,13 @@ export default function Profile({ initialData }: ProfileProps) {
                   key={item.path}
                   to={item.path}
                   className={({ isActive }: { isActive: boolean }) =>
-                    `flex h-12 flex-grow flex-row items-center justify-center sm:flex-grow-0 ${
+                    clsx(
+                      "flex h-12 flex-grow flex-row items-center justify-center sm:flex-grow-0",
                       isActive ?
-                        "-mt-[1px] border-t border-slate-700 text-blue-500 sm:text-gray-900 dark:border-slate-200 dark:sm:text-gray-100"
-                      : "border-none text-gray-700 dark:text-gray-400"
-                    }`
+                        `-mt-[1px] border-t border-slate-700 text-blue-500 sm:text-gray-900
+                          dark:border-slate-200 dark:sm:text-gray-100`
+                      : "border-none text-gray-700 dark:text-gray-400",
+                    )
                   }
                 >
                   <Tab className="flex flex-row items-center justify-start gap-1">

--- a/src/features/profiles/components/ProfilePicInput.tsx
+++ b/src/features/profiles/components/ProfilePicInput.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../core/constants/appConstants";
 import { AxiosError } from "axios";
 import AxiosErrorResponse from "../../core/types/axiosErrorResponse";
+import clsx from "clsx";
 
 const profilePicInputSchema = z
   .object({
@@ -130,14 +131,16 @@ export default function ProfilePicInput() {
             <Button
               autoFocus
               onClick={() => inputFile.current?.click()}
-              className="w-full border-t border-slate-300 py-3 font-semibold text-blue-500 dark:border-slate-600"
+              className="w-full border-t border-slate-300 py-3 font-semibold text-blue-500
+                dark:border-slate-600"
             >
               Upload new photo
             </Button>
             <Button
               autoFocus
               onClick={onPictureDelete}
-              className="w-full border-t border-slate-300 py-3 font-semibold text-red-500 dark:border-slate-600"
+              className="w-full border-t border-slate-300 py-3 font-semibold text-red-500
+                dark:border-slate-600"
             >
               Remove current photo
             </Button>
@@ -153,10 +156,16 @@ export default function ProfilePicInput() {
 
       <Button
         onClick={onPictureClick}
-        className={`absolute left-0 top-0 h-full w-full cursor-pointer overflow-hidden rounded-full ${currentUser?.profilePic ? "" : "bg-black/40"}`}
+        className={clsx(
+          "absolute left-0 top-0 h-full w-full cursor-pointer overflow-hidden rounded-full",
+          currentUser?.profilePic ? "" : "bg-black/40",
+        )}
       >
         {currentUser?.profilePic ? null : (
-          <CameraIconSolid className="absolute left-1/2 top-1/2 size-12 -translate-x-1/2 -translate-y-1/2 text-gray-200" />
+          <CameraIconSolid
+            className="absolute left-1/2 top-1/2 size-12 -translate-x-1/2 -translate-y-1/2
+              text-gray-200"
+          />
         )}
       </Button>
 


### PR DESCRIPTION
This PR changes all occurrences of template literal strings with conditionally applied classes to utilize `clsx` lib/function. On top of that all files have been formatted with Prettier + `prettier-plugin-classnames`, which automatically change `className` strings that exceed maximum `printWidth` length to multiline template literals.

`prettier-plugin-merge` is utilized to combine formatting output from different Prettier plugins (otherwise only last plugin would be used).