### PR TITLE
chore: Add version and build date to /about

### DIFF
--- a/src/features/about/components/About.tsx
+++ b/src/features/about/components/About.tsx
@@ -1,37 +1,45 @@
+import { format } from "date-fns";
 import { Link } from "react-router-dom";
 
 export default function About() {
   const repoURL = import.meta.env.VITE_APP_REPO_URL;
+  const buildDate = format(__BUILD_DATE__, "dd.MM.yyyy");
+  const buildDateTitle = format(__BUILD_DATE__, "MMM dd, yyyy");
 
   return (
     <div className="mx-4 max-w-screen-xl py-12 lg:mx-8 xl:mx-auto">
       <h2 className="mb-2 mt-8 text-2xl">About</h2>
       <div className="flex flex-col justify-start gap-4">
-        <div>Homepage photos by:</div>
-        <ul className="ml-4">
-          <li>
-            <span>{"Pine Watt (Unsplash) - "}</span>
-            <Link
-              to="https://unsplash.com/photos/aerial-shot-of-forest-2Hzmz15wGik"
-              target="_blank"
-              className="text-blue-500 hover:underline dark:text-blue-500"
-            >
-              {"https://unsplash.com/photos/aerial-shot-of-forest-2Hzmz15wGik"}
-            </Link>
-          </li>
-          <li>
-            <span>{"Claudio Testa (Unsplash) - "}</span>
-            <Link
-              to="https://unsplash.com/photos/green-hills-with-forest-under-cloudy-sky-during-daytime--SO3JtE3gZo"
-              target="_blank"
-              className="text-blue-500 hover:underline dark:text-blue-500"
-            >
-              {
-                "https://unsplash.com/photos/green-hills-with-forest-under-cloudy-sky-during-daytime--SO3JtE3gZo"
-              }
-            </Link>
-          </li>
-        </ul>
+        <div>
+          <div>Homepage photos by:</div>
+          <ul className="ml-4">
+            <li>
+              <span>{"Pine Watt (Unsplash) - "}</span>
+              <Link
+                to="https://unsplash.com/photos/aerial-shot-of-forest-2Hzmz15wGik"
+                target="_blank"
+                className="text-blue-500 hover:underline dark:text-blue-500"
+              >
+                {
+                  "https://unsplash.com/photos/aerial-shot-of-forest-2Hzmz15wGik"
+                }
+              </Link>
+            </li>
+            <li>
+              <span>{"Claudio Testa (Unsplash) - "}</span>
+              <Link
+                to="https://unsplash.com/photos/green-hills-with-forest-under-cloudy-sky-during-daytime--SO3JtE3gZo"
+                target="_blank"
+                className="text-blue-500 hover:underline dark:text-blue-500"
+              >
+                {
+                  "https://unsplash.com/photos/green-hills-with-forest-under-cloudy-sky-during-daytime--SO3JtE3gZo"
+                }
+              </Link>
+            </li>
+          </ul>
+        </div>
+
         <div>
           <div>Project repository:</div>
           <Link
@@ -41,6 +49,17 @@ export default function About() {
           >
             {repoURL}
           </Link>{" "}
+        </div>
+
+        <div>
+          <div>
+            <span>Version: </span>
+            <span>{`v${import.meta.env.VITE_APP_VERSION}`}</span>
+          </div>
+          <div>
+            <span>Build date: </span>
+            <time title={buildDateTitle}>{buildDate}</time>
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/core/components/Footer.tsx
+++ b/src/features/core/components/Footer.tsx
@@ -14,7 +14,9 @@ export default function Footer() {
         About
       </Link>
       <span>{`v${import.meta.env.VITE_APP_VERSION}`}</span>
-      <time title={title}>{format(date, "dd.MM.yyyy")}</time>
+      <time dateTime={date} title={title}>
+        {format(date, "dd.MM.yyyy")}
+      </time>
     </footer>
   );
 }


### PR DESCRIPTION
This PR adds version and build date information to About page in order to allow mobile users to view this information, since Footer is hidden below `sm` breakpoint.