### PR TITLE
feat: Make all PhotoUpload features usable below sm breakpoint

### DIFF
--- a/src/features/core/components/Modal.tsx
+++ b/src/features/core/components/Modal.tsx
@@ -34,7 +34,7 @@ export default function Modal({
         transition
         className="fixed inset-0 bg-black/30 duration-150 ease-out data-[closed]:opacity-0"
       />
-      <div className="fixed inset-0 flex w-screen items-center justify-center pb-4 pt-14 sm:p-4">
+      <div className="fixed inset-0 flex w-screen items-center justify-center pb-4 pt-14 md:p-4">
         <Button
           title="Close"
           onClick={onClose}

--- a/src/features/core/components/Modal.tsx
+++ b/src/features/core/components/Modal.tsx
@@ -34,21 +34,23 @@ export default function Modal({
         transition
         className="fixed inset-0 bg-black/30 duration-150 ease-out data-[closed]:opacity-0"
       />
-      <div className="fixed inset-0 flex w-screen items-center justify-center pb-4 pt-10 sm:p-4">
+      <div className="fixed inset-0 flex w-screen items-center justify-center pb-4 pt-14 sm:p-4">
         <Button
           title="Close"
           onClick={onClose}
-          className="absolute right-2 top-2 p-1"
+          className="absolute right-1 top-1 p-1 sm:right-2 sm:top-2"
         >
           <XMarkIcon className="size-7 stroke-2 font-bold text-black dark:text-white" />
         </Button>
         <DialogPanel
-          className={`w-full max-w-full overflow-hidden rounded-xl bg-white shadow-xl duration-150
-            ease-out data-[closed]:scale-95 data-[closed]:opacity-0 sm:max-w-fit
-            dark:bg-gray-800`}
+          className={`flex w-full max-w-full flex-col overflow-hidden rounded-xl bg-white shadow-xl
+            duration-150 ease-out data-[closed]:scale-95 data-[closed]:opacity-0
+            sm:max-w-fit dark:bg-gray-800`}
         >
           {title ? title : null}
-          <div className="h-full w-full">{children}</div>
+          <div className="h-full max-h-[calc(100vh-theme(space.20))] w-full">
+            {children}
+          </div>
         </DialogPanel>
       </div>
     </Dialog>

--- a/src/features/core/components/PopoverMenu.tsx
+++ b/src/features/core/components/PopoverMenu.tsx
@@ -6,6 +6,7 @@ import {
   PopoverPanelProps,
   Transition,
 } from "@headlessui/react";
+import clsx from "clsx";
 
 type PopoverMenuProps = PopoverPanelProps & {
   className?: string;
@@ -20,7 +21,7 @@ export default function PopoverMenu({
   children,
 }: PopoverMenuProps) {
   return (
-    <Popover className={`relative ${className}`}>
+    <Popover className={clsx("relative", className && className)}>
       <PopoverButton>{buttonContent}</PopoverButton>
       <Transition
         as={Fragment}

--- a/src/features/photo/components/PhotoEdit.tsx
+++ b/src/features/photo/components/PhotoEdit.tsx
@@ -20,6 +20,7 @@ import WIP from "../../core/components/WIP";
 import useCurrentUserQuery from "../../core/hooks/useCurrentUserQuery";
 import ProfilePic from "../../core/components/ProfilePic";
 import useBreakpoint from "../../core/hooks/useBreakpoint";
+import clsx from "clsx";
 
 type PhotoEditProps = {
   files: File[];
@@ -56,96 +57,100 @@ export default function PhotoEdit({ files, stage }: PhotoEditProps) {
 
   return (
     <div className="flex h-full w-full flex-row">
-      {isSmBreakpoint || stage === "crop" ?
-        <div className="relative h-full w-full grow basis-1/2 md:min-w-[28rem] md:basis-2/3">
-          <PhotoPreview
-            file={files[selectedFileIndex]}
-            objectFit="object-cover"
-          />
+      <div
+        className={clsx(
+          "relative h-full w-full grow md:min-w-[28rem]",
+          stage === "crop" ? "basis-full" : "basis-1/2 md:basis-2/3",
+          !isSmBreakpoint && stage === "share" ? "hidden" : "block",
+        )}
+      >
+        <PhotoPreview
+          file={files[selectedFileIndex]}
+          objectFit="object-cover"
+        />
 
-          {stage === "crop" ?
-            <div
-              className="absolute bottom-0 mb-3 flex w-full flex-row items-center justify-between gap-4
-                px-4"
-            >
-              <div className="flex flex-row gap-4">
-                <PopoverMenu
-                  anchor={"bottom start"}
-                  buttonContent={
-                    <Button className={buttonStyle}>
-                      <ChevronUpDownIcon className="size-8 rotate-45" />
-                      <span className="sr-only">Crop</span>
-                    </Button>
-                  }
-                >
-                  <WIP />
-                </PopoverMenu>
-                <PopoverMenu
-                  anchor={"bottom start"}
-                  buttonContent={
-                    <Button className={buttonStyle}>
-                      <MagnifyingGlassPlusIcon className="size-6" />
-                      <span className="sr-only">Zoom</span>
-                    </Button>
-                  }
-                >
-                  <WIP />
-                </PopoverMenu>
-              </div>
+        {stage === "crop" ?
+          <div
+            className="absolute bottom-0 mb-3 flex w-full flex-row items-center justify-between gap-4
+              px-4"
+          >
+            <div className="flex flex-row gap-4">
               <PopoverMenu
-                anchor={"bottom end"}
+                anchor={"bottom start"}
                 buttonContent={
                   <Button className={buttonStyle}>
-                    <Square2StackIcon className="size-6 scale-x-[-1] scale-y-[-1]" />
-                    <span className="sr-only">Items</span>
+                    <ChevronUpDownIcon className="size-8 rotate-45" />
+                    <span className="sr-only">Crop</span>
+                  </Button>
+                }
+              >
+                <WIP />
+              </PopoverMenu>
+              <PopoverMenu
+                anchor={"bottom start"}
+                buttonContent={
+                  <Button className={buttonStyle}>
+                    <MagnifyingGlassPlusIcon className="size-6" />
+                    <span className="sr-only">Zoom</span>
                   </Button>
                 }
               >
                 <WIP />
               </PopoverMenu>
             </div>
-          : null}
-          {selectedFileIndex != 0 ?
-            <Button
-              onClick={() => {
-                const newSelectedIndex = selectedFileIndex - 1;
-                if (newSelectedIndex >= 0) {
-                  setSelectedFileIndex(newSelectedIndex);
-                }
-              }}
-              className={`${buttonStyle} absolute bottom-1/2 left-2 top-1/2`}
+            <PopoverMenu
+              anchor={"bottom end"}
+              buttonContent={
+                <Button className={buttonStyle}>
+                  <Square2StackIcon className="size-6 scale-x-[-1] scale-y-[-1]" />
+                  <span className="sr-only">Items</span>
+                </Button>
+              }
             >
-              <ChevronLeftIcon className="size-6" />
-            </Button>
-          : null}
-          {selectedFileIndex < files.length - 1 ?
-            <Button
-              onClick={() => {
-                const newSelectedIndex = selectedFileIndex + 1;
-                if (newSelectedIndex < files.length) {
-                  setSelectedFileIndex(newSelectedIndex);
-                }
-              }}
-              className={`${buttonStyle} absolute bottom-1/2 right-2 top-1/2`}
-            >
-              <ChevronRightIcon className="size-6" />
-            </Button>
-          : null}
-          {fileArray.length > 1 ?
-            <div
-              className="absolute bottom-0 mb-3 inline-flex w-full flex-row items-center justify-center
-                gap-2"
-            >
-              {fileArray.map((item, idx) => (
-                <div
-                  key={item.key}
-                  className={`size-2 rounded-full ${selectedFileIndex === idx ? "bg-blue-500" : "bg-gray-400"}`}
-                />
-              ))}
-            </div>
-          : null}
-        </div>
-      : null}
+              <WIP />
+            </PopoverMenu>
+          </div>
+        : null}
+        {selectedFileIndex != 0 ?
+          <Button
+            onClick={() => {
+              const newSelectedIndex = selectedFileIndex - 1;
+              if (newSelectedIndex >= 0) {
+                setSelectedFileIndex(newSelectedIndex);
+              }
+            }}
+            className={`${buttonStyle} absolute bottom-1/2 left-2 top-1/2`}
+          >
+            <ChevronLeftIcon className="size-6" />
+          </Button>
+        : null}
+        {selectedFileIndex < files.length - 1 ?
+          <Button
+            onClick={() => {
+              const newSelectedIndex = selectedFileIndex + 1;
+              if (newSelectedIndex < files.length) {
+                setSelectedFileIndex(newSelectedIndex);
+              }
+            }}
+            className={`${buttonStyle} absolute bottom-1/2 right-2 top-1/2`}
+          >
+            <ChevronRightIcon className="size-6" />
+          </Button>
+        : null}
+        {fileArray.length > 1 ?
+          <div
+            className="absolute bottom-0 mb-3 inline-flex w-full flex-row items-center justify-center
+              gap-2"
+          >
+            {fileArray.map((item, idx) => (
+              <div
+                key={item.key}
+                className={`size-2 rounded-full ${selectedFileIndex === idx ? "bg-blue-500" : "bg-gray-400"}`}
+              />
+            ))}
+          </div>
+        : null}
+      </div>
 
       {stage === "share" ?
         <ConnectForm>
@@ -189,7 +194,7 @@ export default function PhotoEdit({ files, stage }: PhotoEditProps) {
 
                   {fields.map((field, index) => (
                     <div key={field.id} className="flex w-full flex-row gap-2">
-                      <div className="size-12 w-fit">
+                      <div className="size-12 shrink-0">
                         <PhotoPreview
                           file={files[index]}
                           objectFit="object-cover"

--- a/src/features/photo/components/PhotoUpload.tsx
+++ b/src/features/photo/components/PhotoUpload.tsx
@@ -210,8 +210,8 @@ export default function PhotoUpload({ isOpen, setIsOpen }: PhotoUploadProps) {
           >
             <div
               className={clsx(
-                `flex h-[30rem] w-full flex-col items-center justify-center rounded-b-xl
-                transition`,
+                `h-[calc(min(30rem,_100vh-theme(space.20)))] flex w-full flex-col items-center
+                justify-center rounded-b-xl transition`,
                 isDragActive ? "bg-black/5 dark:bg-black/50" : "",
               )}
             >


### PR DESCRIPTION
This PR fixes content overflowing + `share` and close button overlap in `PhotoUpload` modal, both of which occurred under `sm` screen width breakpoint.