### PR TITLE
feat: Make Drawer and Search users tab response under 'sm' breakpoint

### DIFF
--- a/src/features/core/components/Drawer.tsx
+++ b/src/features/core/components/Drawer.tsx
@@ -27,16 +27,16 @@ export default function Drawer({
         <div className="absolute inset-0 overflow-hidden">
           <div
             className={clsx(
-              "fixed inset-y-0 flex max-w-full",
+              "fixed inset-y-0 mb-12 flex w-full max-w-full sm:mb-0 sm:w-fit",
               position ? position : "left-0",
             )}
           >
             <DialogPanel
               transition
-              className={`sm:duration-400 pointer-events-auto relative w-screen max-w-64 translate-x-0
-                rounded-e-xl border-e border-slate-300 bg-white transition duration-300
-                ease-in-out data-[closed]:-translate-x-full sm:max-w-sm dark:border-slate-600
-                dark:bg-gray-900`}
+              className={`sm:duration-400 pointer-events-auto relative w-screen max-w-full translate-x-0
+                rounded-none border-e border-slate-300 bg-white transition duration-300
+                ease-in-out data-[closed]:-translate-x-full sm:max-w-sm sm:rounded-e-xl
+                dark:border-slate-600 dark:bg-gray-900`}
             >
               <div className="flex h-full flex-col overflow-y-auto py-6 shadow-xl">
                 <div className="px-4 sm:px-6">

--- a/src/features/core/components/Navbar.tsx
+++ b/src/features/core/components/Navbar.tsx
@@ -208,17 +208,17 @@ export default function Navbar() {
         isOpen={searchDrawerOpen}
         title="Search"
         onClose={onSearchClose}
-        position="left-[76px]"
+        position="left-0 sm:left-[76px]"
       >
         <SearchUsers />
       </Drawer>
 
       <header
         className={clsx(
-          `fixed bottom-0 z-10 h-12 shrink-0 overflow-y-auto border-r-0 border-t
-          border-slate-300 bg-white sm:static sm:h-screen sm:border-r sm:border-t-0
-          dark:border-slate-600 dark:bg-gray-900`,
-          searchDrawerOpen ? "mr-44 w-fit" : "w-full sm:w-fit xl:w-64",
+          `fixed bottom-0 z-10 h-12 w-full shrink-0 overflow-y-auto border-r-0 border-t
+          border-slate-300 bg-white sm:static sm:h-screen sm:w-fit sm:border-r
+          sm:border-t-0 dark:border-slate-600 dark:bg-gray-900`,
+          searchDrawerOpen ? "mr-0 sm:mr-[11.4rem]" : "xl:w-64",
         )}
       >
         <nav


### PR DESCRIPTION
Previously `Drawer` component would be displayed close to the middle of the screen with margin on the left side, which was caused by the change to `Navbar` positioning under `sm` breakpoint. This PR changes `Drawer` component to cover all available screen space when displayed under `sm` breakpoint and adjusts its position to not overlap `Navbar` when it's positioned at the bottom of the screen.