### PR TITLE
chore: Reset all queries on user login

### DIFF
--- a/src/features/accounts/components/LoginForm.tsx
+++ b/src/features/accounts/components/LoginForm.tsx
@@ -3,8 +3,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import SiteLogo from "../../core/components/SiteLogo";
 import Input from "../../core/components/Input";
-import { Link, useNavigate } from "react-router-dom";
-import { useMutation } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { postLogin } from "../api/queries";
 import ApiError from "../../core/components/ApiError";
 import WIP from "../../core/components/WIP";
@@ -25,11 +25,11 @@ export default function LoginForm() {
   } = useForm({
     resolver: zodResolver(schema),
   });
-  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: postLogin,
-    onSuccess: () => {
-      navigate("/", { replace: true });
+    onSuccess: async () => {
+      await queryClient.resetQueries();
     },
   });
   const onSubmit = handleSubmit(async (data) => {


### PR DESCRIPTION
Recommended users could persist after logging out as `user_1` and logging in as `user_2` without refreshing the page, which could cause displaying the currently logged in user as a follow recommendation.

This PR resets query cache on successful login, which fixes this issue and will prevent similar bugs in the future, where personalized content is persisted between sessions of different users.