### PR TITLE
feat: Implement guest login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ export default function App() {
         autoClose={5000}
         limit={4}
         transition={Slide}
-        className={() => "fixed bottom-0 z-50 w-full"}
+        className={() => "fixed bottom-0 z-[60] w-full"}
         toastClassName={() =>
           "relative flex p-2 min-h-10 justify-between overflow-hidden border-t border-slate-300 dark:border-slate-600 shadow-xl bg-white dark:bg-gray-900 dark:text-gray-200"
         }

--- a/src/features/accounts/api/queries.ts
+++ b/src/features/accounts/api/queries.ts
@@ -1,8 +1,8 @@
 import api from "../../core/api/api";
-import User from "../../core/types/user";
+import CurrentUser from "../../core/types/currentUser";
 
 const getCurrentUser = async () => {
-  return api.get<User>("/auth/me").then((response) => {
+  return api.get<CurrentUser>("/auth/me").then((response) => {
     return response.data;
   });
 };
@@ -12,7 +12,7 @@ const postSignup = async (userDTO: {
   email: string;
   password: string;
 }) => {
-  return api.post<User>("/auth/signup", userDTO).then((response) => {
+  return api.post<CurrentUser>("/auth/signup", userDTO).then((response) => {
     return response.data;
   });
 };
@@ -21,13 +21,13 @@ const postLogin = async (userLoginDTO: {
   userId: string;
   password: string;
 }) => {
-  return api.post<User>("/auth/login", userLoginDTO).then((response) => {
+  return api.post<CurrentUser>("/auth/login", userLoginDTO).then((response) => {
     return response.data;
   });
 };
 
 const postLoginGuest = async () => {
-  return api.post<User>("/auth/guest").then((response) => {
+  return api.post<CurrentUser>("/auth/guest").then((response) => {
     return response.data;
   });
 };

--- a/src/features/accounts/api/queries.ts
+++ b/src/features/accounts/api/queries.ts
@@ -26,10 +26,16 @@ const postLogin = async (userLoginDTO: {
   });
 };
 
+const postLoginGuest = async () => {
+  return api.post<User>("/auth/guest").then((response) => {
+    return response.data;
+  });
+};
+
 const postLogout = async () => {
   return api.post("/auth/logout").then((response) => {
     return response.data;
   });
 };
 
-export { getCurrentUser, postSignup, postLogin, postLogout };
+export { getCurrentUser, postSignup, postLogin, postLoginGuest, postLogout };

--- a/src/features/accounts/components/LoginForm.tsx
+++ b/src/features/accounts/components/LoginForm.tsx
@@ -8,6 +8,11 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { postLogin, postLoginGuest } from "../api/queries";
 import ApiError from "../../core/components/ApiError";
 import { Button } from "@headlessui/react";
+import PopoverTooltip from "../../core/components/PopoverTooltip";
+import {
+  ArrowLeftEndOnRectangleIcon,
+  QuestionMarkCircleIcon,
+} from "@heroicons/react/24/outline";
 
 const schema = z
   .object({
@@ -99,9 +104,26 @@ export default function LoginForm() {
           <div className="inline w-full border-t border-slate-300 dark:border-slate-600" />
         </div>
 
-        <div className="mt-6 w-full text-center">
-          <div>Proceed as guest</div>
-          <Button onClick={() => guestMutation.mutate()}>Login as guest</Button>
+        <div className="mt-2 w-full text-center">
+          <div className="relative mx-auto w-fit">
+            <div className="h-8 text-center text-lg font-semibold leading-8">
+              Proceed as guest
+            </div>
+            <div className="absolute -right-9 top-0">
+              <PopoverTooltip
+                label={`Preview content and features without creating an account.`}
+              >
+                <QuestionMarkCircleIcon className="size-8" />
+              </PopoverTooltip>
+            </div>
+          </div>
+          <Button
+            onClick={() => guestMutation.mutate()}
+            className="mt-4 flex w-full flex-row justify-center gap-2 font-semibold text-blue-500 active:text-blue-400"
+          >
+            <ArrowLeftEndOnRectangleIcon className="size-6" />
+            Enter as guest
+          </Button>
         </div>
       </div>
 

--- a/src/features/accounts/components/LoginForm.tsx
+++ b/src/features/accounts/components/LoginForm.tsx
@@ -5,9 +5,8 @@ import SiteLogo from "../../core/components/SiteLogo";
 import Input from "../../core/components/Input";
 import { Link } from "react-router-dom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { postLogin } from "../api/queries";
+import { postLogin, postLoginGuest } from "../api/queries";
 import ApiError from "../../core/components/ApiError";
-import WIP from "../../core/components/WIP";
 import { Button } from "@headlessui/react";
 
 const schema = z
@@ -32,6 +31,14 @@ export default function LoginForm() {
       await queryClient.resetQueries();
     },
   });
+
+  const guestMutation = useMutation({
+    mutationFn: postLoginGuest,
+    onSuccess: async () => {
+      await queryClient.resetQueries();
+    },
+  });
+
   const onSubmit = handleSubmit(async (data) => {
     mutation.mutate({
       userId: data.userId,
@@ -93,8 +100,8 @@ export default function LoginForm() {
         </div>
 
         <div className="mt-6 w-full text-center">
-          <span>Proceed as guest</span>
-          <WIP />
+          <div>Proceed as guest</div>
+          <Button onClick={() => guestMutation.mutate()}>Login as guest</Button>
         </div>
       </div>
 

--- a/src/features/core/components/PopoverTooltip.tsx
+++ b/src/features/core/components/PopoverTooltip.tsx
@@ -15,10 +15,10 @@ type PopoverTooltipProps = PopoverPanelProps & {
 };
 
 export default function PopoverTooltip({
-  className,
+  label,
   anchor = "bottom",
   timeoutDuration = 100,
-  label,
+  className = "",
   children,
 }: PopoverTooltipProps) {
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -36,7 +36,7 @@ export default function PopoverTooltip({
   };
 
   return (
-    <Popover className={`relative w-fit ${className ? className : ""}`}>
+    <Popover className={`relative w-fit ${className}`}>
       {({ open }) => (
         <div
           onMouseEnter={() => handleEnter(open)}
@@ -59,7 +59,8 @@ export default function PopoverTooltip({
           >
             <PopoverPanel
               anchor={anchor}
-              className="flex flex-col whitespace-pre-line rounded-xl bg-gray-200 p-2 dark:bg-gray-600"
+              className="flex flex-col whitespace-pre-line rounded-xl bg-gray-200 p-2 text-gray-900
+                dark:bg-gray-600 dark:text-gray-200"
             >
               {label}
             </PopoverPanel>

--- a/src/features/core/components/RoleGuard.tsx
+++ b/src/features/core/components/RoleGuard.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from "react";
+import useCurrentUserQuery from "../hooks/useCurrentUserQuery";
+import UserRole from "../types/userRole";
+
+type RoleGuardProps = {
+  role: UserRole[];
+  forbidden?: () => ReactNode;
+  children: ReactNode;
+};
+
+export default function RoleGuard({
+  role,
+  forbidden,
+  children,
+}: RoleGuardProps) {
+  const { data: currentUser } = useCurrentUserQuery();
+  const isAuthorized = currentUser ? role.includes(currentUser?.role) : false;
+
+  return <>{isAuthorized ? children : forbidden}</>;
+}

--- a/src/features/core/types/currentUser.ts
+++ b/src/features/core/types/currentUser.ts
@@ -1,0 +1,11 @@
+import Photo from "./photo";
+import UserRole from "./userRole";
+
+type CurrentUser = {
+  _id: string | number;
+  name: string;
+  profilePic?: Photo;
+  role: UserRole;
+};
+
+export default CurrentUser;

--- a/src/features/core/types/user.ts
+++ b/src/features/core/types/user.ts
@@ -3,7 +3,6 @@ import Photo from "./photo";
 type User = {
   _id: string | number;
   name: string;
-  email: string;
   description: string;
   profilePic?: Photo;
   posts: number;

--- a/src/features/core/types/userRole.ts
+++ b/src/features/core/types/userRole.ts
@@ -1,0 +1,6 @@
+enum UserRole {
+  User = "USER",
+  Guest = "GUEST",
+}
+
+export default UserRole;

--- a/src/features/core/utils/toaster.tsx
+++ b/src/features/core/utils/toaster.tsx
@@ -6,13 +6,13 @@ type ToastMessageProps = {
   text: string;
 };
 
-const toaster = (myProps: ToastMessageProps, toastProps?: ToastOptions): Id =>
-  toast(<ToastMessage {...myProps} />, { ...toastProps });
+const toaster = (messageProps: ToastMessageProps, toastProps?: ToastOptions): Id =>
+  toast(<ToastMessage {...messageProps} />, { ...toastProps });
 
-toaster.success = (myProps: ToastMessageProps, toastProps?: ToastOptions): Id =>
-  toast.success(<ToastMessage {...myProps} />, { ...toastProps });
+toaster.success = (messageProps: ToastMessageProps, toastProps?: ToastOptions): Id =>
+  toast.success(<ToastMessage {...messageProps} />, { ...toastProps });
 
-toaster.error = (myProps: ToastMessageProps, toastProps?: ToastOptions): Id =>
-  toast.error(<ToastMessage {...myProps} />, { ...toastProps });
+toaster.error = (messageProps: ToastMessageProps, toastProps?: ToastOptions): Id =>
+  toast.error(<ToastMessage {...messageProps} />, { ...toastProps });
 
 export default toaster;

--- a/src/features/feed/components/RecommendedUsers.tsx
+++ b/src/features/feed/components/RecommendedUsers.tsx
@@ -6,6 +6,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { deleteFollow, postFollow } from "../../core/api/queries";
 import UserRecommendation from "../../core/types/userRecommendation";
 import { NavLink } from "react-router-dom";
+import RoleGuard from "../../core/components/RoleGuard";
+import UserRole from "../../core/types/userRole";
+import { InformationCircleIcon } from "@heroicons/react/24/outline";
 
 export default function RecommendedUsers() {
   const queryClient = useQueryClient();
@@ -66,34 +69,44 @@ export default function RecommendedUsers() {
       <span className="text-sm font-semibold text-gray-500 dark:text-gray-400">
         Suggested for you
       </span>
-      {!isLoading ?
-        <>
-          {recommendedUsers.map((userRec) => (
-            <div
-              key={userRec._id}
-              className="mx-2 flex flex-row items-center justify-between"
-            >
-              <div className="flex flex-row items-center gap-3">
-                <NavLink to={`/${userRec.name}`}>
-                  <div className="size-10">
-                    <ProfilePic photo={userRec.profilePic} />
-                  </div>
-                </NavLink>
-                <NavLink to={`/${userRec.name}`}>
-                  <span>{userRec.name}</span>
-                </NavLink>
-              </div>
-
-              <Button
-                onClick={() => onFollowClick(userRec._id)}
-                className="text-xs font-semibold text-blue-500 hover:text-gray-700 dark:hover:text-gray-200"
+      <RoleGuard role={[UserRole.User]}>
+        {!isLoading ?
+          <>
+            {recommendedUsers.map((userRec) => (
+              <div
+                key={userRec._id}
+                className="mx-2 flex flex-row items-center justify-between"
               >
-                {userRec.follow ? "Following" : "Follow"}
-              </Button>
-            </div>
-          ))}
-        </>
-      : null}
+                <div className="flex flex-row items-center gap-3">
+                  <NavLink to={`/${userRec.name}`}>
+                    <div className="size-10">
+                      <ProfilePic photo={userRec.profilePic} />
+                    </div>
+                  </NavLink>
+                  <NavLink to={`/${userRec.name}`}>
+                    <span>{userRec.name}</span>
+                  </NavLink>
+                </div>
+
+                <Button
+                  onClick={() => onFollowClick(userRec._id)}
+                  className="text-xs font-semibold text-blue-500 hover:text-gray-700 dark:hover:text-gray-200"
+                >
+                  {userRec.follow ? "Following" : "Follow"}
+                </Button>
+              </div>
+            ))}
+          </>
+        : null}
+      </RoleGuard>
+      <RoleGuard role={[UserRole.Guest]}>
+        <div className="flex flex-row items-center gap-2 text-gray-500 dark:text-gray-400">
+          <InformationCircleIcon className="size-6 shrink-0" />
+          <span className="text-sm">
+            Recommendations are only available to logged in users
+          </span>
+        </div>
+      </RoleGuard>
     </aside>
   );
 }


### PR DESCRIPTION
This PR enables users to enter the main site as guests, which allows them to preview content and features of the site without creating an account.

A global `react-query` error handler for unauthorized errors has been added, which will display a toast message informing the user that they must be logged in to access the feature. Toast message element has also been moved up in `z-index` in order to appear above modal windows.

Differentiation between types for general user information - `User` (for posts, etc.) and currently logged in user - `CurrentUser` has been added. `CurrentUser` type only contains data necessary for displaying correct UI elements for the logged in user, including new attribute - `role`. This attribute is used by a new utility component `RoleGuard` which takes required role as a prop and checks it against user's role in order to determine if content should be rendered.