### PR TITLE
refactor: Refactor Feed view components

### DIFF
--- a/src/features/errors/components/QueryError.tsx
+++ b/src/features/errors/components/QueryError.tsx
@@ -1,0 +1,20 @@
+import { AxiosError } from "axios";
+import AxiosErrorResponse from "../../core/types/axiosErrorResponse";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
+
+type QueryErrorMessageProps = {
+  error: AxiosError<AxiosErrorResponse>;
+};
+
+export default function QueryError({ error }: QueryErrorMessageProps) {
+  const message =
+    error.response?.data ? error.response.data.message : error.message;
+
+  return (
+    <div className="mt-16 flex flex-col items-center justify-center">
+      <ExclamationTriangleIcon className="size-14 text-gray-800 dark:text-gray-400" />
+      <div className="mx-auto w-fit text-center">Error</div>
+      <div className="mx-auto w-fit text-center">{message}</div>
+    </div>
+  );
+}

--- a/src/features/feed/api/loaders.ts
+++ b/src/features/feed/api/loaders.ts
@@ -1,17 +1,15 @@
 import { QueryClient } from "@tanstack/react-query";
 import { LoaderFunctionArgs } from "react-router-dom";
-import { followingPostsQuery, forYouPostsQuery } from "../api/queries";
+import { feedPostsQuery } from "../api/queries";
 import { recommendedUsersQuery } from "./queries";
 
 export const feedLoader =
   (queryClient: QueryClient) =>
   async ({ request }: LoaderFunctionArgs) => {
-    const variant = new URL(request.url).searchParams.get("variant");
-    const postsQuery =
-      variant === "following" ? followingPostsQuery : forYouPostsQuery;
+    const variant = new URL(request.url).searchParams.get("variant") || "";
 
     const postsPromise = queryClient
-      .ensureQueryData(postsQuery())
+      .ensureQueryData(feedPostsQuery(variant))
       .then((data) => {
         return data;
       })

--- a/src/features/feed/api/queries.ts
+++ b/src/features/feed/api/queries.ts
@@ -39,4 +39,23 @@ const followingPostsQuery = () => ({
   queryFn: async () => getFollowingPosts(),
 });
 
-export { recommendedUsersQuery, forYouPostsQuery, followingPostsQuery };
+const feedPostsQuery = (variant: string) => ({
+  queryKey: ["posts", "feed", variant],
+  queryFn: () => {
+    switch (variant) {
+      case "for-you":
+        return getForYouPosts();
+      case "following":
+        return getFollowingPosts();
+      default:
+        return getForYouPosts();
+    }
+  },
+});
+
+export {
+  recommendedUsersQuery,
+  forYouPostsQuery,
+  followingPostsQuery,
+  feedPostsQuery,
+};

--- a/src/features/feed/components/Feed.tsx
+++ b/src/features/feed/components/Feed.tsx
@@ -2,12 +2,10 @@ import { useEffect } from "react";
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
 import PostPreview from "../../posts/components/PostPreview";
-import RecommendedUsers from "./RecommendedUsers";
-import ProfilePic from "../../core/components/ProfilePic";
-import useCurrentUserQuery from "../../core/hooks/useCurrentUserQuery";
 import useFollowingPostsQuery from "../hooks/useFollowingPostsQuery";
 import useForYouPostsQuery from "../hooks/useForYouPostsQuery";
 import clsx from "clsx";
+import FeedSidebar from "./FeedSidebar";
 
 export default function Feed() {
   const navigate = useNavigate();
@@ -17,7 +15,6 @@ export default function Feed() {
     pageVariant === "following" ? useFollowingPostsQuery : useForYouPostsQuery;
   const { data: posts } = usePostsQuery();
   const postCount = posts?.length || 0;
-  const { data: currentUser } = useCurrentUserQuery();
 
   useEffect(() => {
     if (pageVariant !== "for-you" && pageVariant !== "following") {
@@ -89,18 +86,7 @@ export default function Feed() {
         </div>
       </div>
 
-      <div className="mt-8 hidden w-64 flex-col gap-4 xl:flex">
-        <div className="flex flex-row items-center gap-3">
-          <NavLink to={`/${currentUser?.name}`} className="size-10">
-            <ProfilePic photo={currentUser?.profilePic} />
-          </NavLink>
-          <NavLink to={`/${currentUser?.name}`}>
-            <div>{currentUser?.name}</div>
-          </NavLink>
-        </div>
-
-        <RecommendedUsers />
-      </div>
+      <FeedSidebar />
     </div>
   );
 }

--- a/src/features/feed/components/Feed.tsx
+++ b/src/features/feed/components/Feed.tsx
@@ -1,23 +1,17 @@
 import { useEffect } from "react";
-import { NavLink, useLocation, useNavigate } from "react-router-dom";
-import { CheckCircleIcon } from "@heroicons/react/24/outline";
-import PostPreview from "../../posts/components/PostPreview";
-import useFollowingPostsQuery from "../hooks/useFollowingPostsQuery";
-import useForYouPostsQuery from "../hooks/useForYouPostsQuery";
-import clsx from "clsx";
+import { useLocation, useNavigate } from "react-router-dom";
+import FeedNavigation from "./FeedNavigation";
+import FeedPostList from "./FeedPostList";
 import FeedSidebar from "./FeedSidebar";
+import WIP from "../../core/components/WIP";
 
 export default function Feed() {
   const navigate = useNavigate();
   const { search } = useLocation();
-  const pageVariant = new URLSearchParams(search).get("variant");
-  const usePostsQuery =
-    pageVariant === "following" ? useFollowingPostsQuery : useForYouPostsQuery;
-  const { data: posts } = usePostsQuery();
-  const postCount = posts?.length || 0;
+  const pageVariant = new URLSearchParams(search).get("variant") || "";
 
   useEffect(() => {
-    if (pageVariant !== "for-you" && pageVariant !== "following") {
+    if (!["for-you", "following"].includes(pageVariant)) {
       navigate("?variant=for-you", { replace: true });
     }
   }, [navigate, pageVariant]);
@@ -28,60 +22,16 @@ export default function Feed() {
         className="mx-0 w-full max-w-fit flex-grow overflow-auto sm:mx-4 md:mx-8 md:w-[32rem]
           lg:max-w-[46rem] xl:mx-16"
       >
-        <div
-          className="flex w-full max-w-2xl flex-row items-center justify-start gap-3 border-b
-            border-slate-300 px-2 font-bold sm:px-0 dark:border-slate-600"
-        >
-          <NavLink to="?variant=for-you" end className="py-2">
-            {({ isActive }) => (
-              <span
-                className={clsx(
-                  isActive && pageVariant === "for-you" ?
-                    ""
-                  : "text-gray-400 dark:text-gray-700",
-                )}
-              >
-                For you
-              </span>
-            )}
-          </NavLink>
-          <NavLink to="?variant=following" end className="py-2">
-            {({ isActive }) => (
-              <span
-                className={clsx(
-                  isActive && pageVariant === "following" ?
-                    ""
-                  : "text-gray-400 dark:text-gray-700",
-                )}
-              >
-                Following
-              </span>
-            )}
-          </NavLink>
-        </div>
+        <FeedNavigation variant={pageVariant} />
 
         <div className="mx-auto w-[28rem] max-w-full sm:w-[28rem]">
           <div className="w-full py-4">
-            {postCount > 0 ?
-              <div className="flex flex-col gap-4">
-                {posts?.map((post, index) => (
-                  <div key={post._id}>
-                    <PostPreview post={post} />
-                    {index < posts.length - 1 ?
-                      <div className="mt-4 border-b border-slate-300 dark:border-slate-600" />
-                    : null}
-                  </div>
-                ))}
-              </div>
-            : <div className="flex flex-col items-center justify-center py-12">
-                <CheckCircleIcon className="size-28 stroke-[0.5]" />
-                <span>{"No new posts"}</span>
-              </div>
-            }
+            <FeedPostList variant={pageVariant} />
           </div>
 
           <div className="mt-4 hidden flex-col border-t border-slate-300 dark:border-slate-600">
             <span className="text-lg">Suggested posts</span>
+            <WIP />
           </div>
         </div>
       </div>

--- a/src/features/feed/components/FeedNavigation.tsx
+++ b/src/features/feed/components/FeedNavigation.tsx
@@ -1,0 +1,42 @@
+import clsx from "clsx";
+import { NavLink } from "react-router-dom";
+
+type FeedNavigationProps = {
+  variant: string;
+};
+
+export default function FeedNavigation({ variant }: FeedNavigationProps) {
+  return (
+    <div
+      className="flex w-full flex-row items-center justify-start gap-3 border-b border-slate-300
+        px-2 font-bold sm:px-0 dark:border-slate-600"
+    >
+      <NavLink to="?variant=for-you" end className="py-2">
+        {({ isActive }) => (
+          <span
+            className={clsx(
+              isActive && variant === "for-you" ?
+                ""
+              : "text-gray-400 dark:text-gray-700",
+            )}
+          >
+            For you
+          </span>
+        )}
+      </NavLink>
+      <NavLink to="?variant=following" end className="py-2">
+        {({ isActive }) => (
+          <span
+            className={clsx(
+              isActive && variant === "following" ?
+                ""
+              : "text-gray-400 dark:text-gray-700",
+            )}
+          >
+            Following
+          </span>
+        )}
+      </NavLink>
+    </div>
+  );
+}

--- a/src/features/feed/components/FeedPostList.tsx
+++ b/src/features/feed/components/FeedPostList.tsx
@@ -1,0 +1,43 @@
+import useFeedPostsQuery from "../hooks/useFeedPostsQuery";
+import PostPreview from "../../posts/components/PostPreview";
+import QueryError from "../../errors/components/QueryError";
+import Spinner from "../../core/components/Spinner";
+import { CheckCircleIcon } from "@heroicons/react/24/outline";
+
+type FeedPostListProps = {
+  variant: string;
+};
+
+export default function FeedPostList({ variant }: FeedPostListProps) {
+  const { data: posts, isPending, error } = useFeedPostsQuery(variant);
+
+  if (isPending) {
+    return (
+      <div className="mx-auto mt-16 w-fit">
+        <Spinner />
+      </div>
+    );
+  }
+  if (error) {
+    return <QueryError error={error} />;
+  }
+
+  return (
+    <>
+      {posts.length ?
+        <div className="flex flex-col gap-4">
+          {posts.map((post) => (
+            <div key={post._id}>
+              <PostPreview post={post} />
+              <div className="mt-4 border-b border-slate-300 dark:border-slate-600" />
+            </div>
+          ))}
+        </div>
+      : <div className="flex flex-col items-center justify-center py-12">
+          <CheckCircleIcon className="size-28 stroke-[0.5]" />
+          <span>{"No new posts"}</span>
+        </div>
+      }
+    </>
+  );
+}

--- a/src/features/feed/components/FeedSidebar.tsx
+++ b/src/features/feed/components/FeedSidebar.tsx
@@ -1,0 +1,23 @@
+import { NavLink } from "react-router-dom";
+import ProfilePic from "../../core/components/ProfilePic";
+import RecommendedUsers from "./RecommendedUsers";
+import useCurrentUserQuery from "../../core/hooks/useCurrentUserQuery";
+
+export default function FeedSidebar() {
+  const { data: currentUser } = useCurrentUserQuery();
+
+  return (
+    <div className="mt-8 hidden w-80 flex-col gap-4 px-4 xl:flex">
+      <div className="flex flex-row items-center gap-3">
+        <NavLink to={`/${currentUser?.name}`} className="size-10">
+          <ProfilePic photo={currentUser?.profilePic} />
+        </NavLink>
+        <NavLink to={`/${currentUser?.name}`}>
+          <div>{currentUser?.name}</div>
+        </NavLink>
+      </div>
+
+      <RecommendedUsers />
+    </div>
+  );
+}

--- a/src/features/feed/components/RecommendedUser.tsx
+++ b/src/features/feed/components/RecommendedUser.tsx
@@ -1,0 +1,29 @@
+import { NavLink } from "react-router-dom";
+import UserRecommendation from "../types/userRecommendation";
+import ProfilePic from "../../core/components/ProfilePic";
+import FollowTextButton from "../../follows/components/FollowTextButton";
+
+type UserRecommendationProps = {
+  userRecommendation: UserRecommendation;
+};
+
+export default function RecommendedUser({
+  userRecommendation,
+}: UserRecommendationProps) {
+  return (
+    <div className="flex grow flex-row items-center justify-between px-2">
+      <div className="flex flex-row items-center gap-3">
+        <NavLink to={`/${userRecommendation.name}`}>
+          <div className="size-10">
+            <ProfilePic photo={userRecommendation.profilePic} />
+          </div>
+        </NavLink>
+        <NavLink to={`/${userRecommendation.name}`}>
+          <span>{userRecommendation.name}</span>
+        </NavLink>
+      </div>
+
+      <FollowTextButton userId={userRecommendation._id} />
+    </div>
+  );
+}

--- a/src/features/feed/components/RecommendedUsers.tsx
+++ b/src/features/feed/components/RecommendedUsers.tsx
@@ -1,10 +1,9 @@
-import ProfilePic from "../../core/components/ProfilePic";
 import useRecommendedUsersQuery from "../hooks/useRecommendedUsersQuery";
-import { NavLink } from "react-router-dom";
-import RoleGuard from "../../core/components/RoleGuard";
 import UserRole from "../../core/types/userRole";
+import RoleGuard from "../../core/components/RoleGuard";
+import Spinner from "../../core/components/Spinner";
+import RecommendedUser from "./RecommendedUser";
 import { InformationCircleIcon } from "@heroicons/react/24/outline";
-import FollowTextButton from "../../follows/components/FollowTextButton";
 
 export default function RecommendedUsers() {
   const { data: recommendedUsers = [], isLoading } = useRecommendedUsersQuery();
@@ -16,28 +15,15 @@ export default function RecommendedUsers() {
       </span>
       <RoleGuard role={[UserRole.User]}>
         {!isLoading ?
-          <>
+          <div className="flex flex-col gap-4">
             {recommendedUsers.map((userRec) => (
-              <div
-                key={userRec._id}
-                className="mx-2 flex flex-row items-center justify-between"
-              >
-                <div className="flex flex-row items-center gap-3">
-                  <NavLink to={`/${userRec.name}`}>
-                    <div className="size-10">
-                      <ProfilePic photo={userRec.profilePic} />
-                    </div>
-                  </NavLink>
-                  <NavLink to={`/${userRec.name}`}>
-                    <span>{userRec.name}</span>
-                  </NavLink>
-                </div>
-
-                <FollowTextButton userId={userRec._id} />
-              </div>
+              <RecommendedUser key={userRec._id} userRecommendation={userRec} />
             ))}
-          </>
-        : null}
+          </div>
+        : <div className="flex min-h-[264px] flex-col items-center justify-center gap-4">
+            <Spinner />
+          </div>
+        }
       </RoleGuard>
       <RoleGuard role={[UserRole.Guest]}>
         <div className="flex flex-row items-center gap-2 text-gray-500 dark:text-gray-400">

--- a/src/features/feed/hooks/useFeedPostsQuery.ts
+++ b/src/features/feed/hooks/useFeedPostsQuery.ts
@@ -1,0 +1,6 @@
+import { useQuery } from "@tanstack/react-query";
+import { feedPostsQuery } from "../api/queries";
+
+export default function useFeedPostsQuery(variant: string) {
+  return useQuery(feedPostsQuery(variant));
+}

--- a/src/features/feed/hooks/useFollowingPostsQuery.ts
+++ b/src/features/feed/hooks/useFollowingPostsQuery.ts
@@ -1,6 +1,0 @@
-import { useQuery } from "@tanstack/react-query";
-import { followingPostsQuery } from "../api/queries";
-
-export default function useFollowingPostsQuery() {
-  return useQuery(followingPostsQuery());
-}

--- a/src/features/feed/hooks/useForYouPostsQuery.ts
+++ b/src/features/feed/hooks/useForYouPostsQuery.ts
@@ -1,6 +1,0 @@
-import { useQuery } from "@tanstack/react-query";
-import { forYouPostsQuery } from "../api/queries";
-
-export default function useForYouPostsQuery() {
-  return useQuery(forYouPostsQuery());
-}


### PR DESCRIPTION
`Feed` component has been split into smaller ones to improve readability and better separate concerns. `followingPostsQuery` and `forYouPostsQuery` hooks have been merged into a single query, which takes feed page variant as a parameter, which enabled removal of conditional hook choice in `Feed`.