### PR TITLE
chore: Improve queryClient usage

### DIFF
--- a/src/features/posts/api/loaders.ts
+++ b/src/features/posts/api/loaders.ts
@@ -35,33 +35,32 @@ export const postDetailsLoader =
       };
     }
 
-    const post = await queryClient
+    const likePromise = queryClient.ensureQueryData(
+      postLikeQuery(params.postId),
+    );
+    const { post, follow } = await queryClient
       .ensureQueryData(postQuery(params.postId))
-      .then((data) => {
-        return data;
-      })
-      .catch(() => {
-        return null;
-      });
-    const like = await queryClient
-      .ensureQueryData(postLikeQuery(params.postId))
-      .then((data) => {
-        return data;
-      })
-      .catch(() => {
-        return null;
-      });
-    const follow =
-      post?.user ?
-        await queryClient
-          .ensureQueryData(followQuery(post.user._id))
+      .then(async (data) => {
+        const follow = await queryClient
+          .ensureQueryData(followQuery(data.user._id))
           .then((data) => {
             return data;
           })
           .catch(() => {
             return null;
-          })
-      : null;
+          });
+        return { post: data, follow };
+      })
+      .catch(() => {
+        return { post: null, follow: null };
+      });
+    const like = await likePromise
+      .then((data) => {
+        return data;
+      })
+      .catch(() => {
+        return null;
+      });
 
     return { post, like, follow };
   };

--- a/src/features/posts/hooks/usePostDelete.ts
+++ b/src/features/posts/hooks/usePostDelete.ts
@@ -7,14 +7,15 @@ export default function usePostDelete() {
 
   return useMutation({
     mutationFn: (post: Post) => deletePost(post._id),
-    onSuccess: async (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ["posts", variables._id],
-        exact: false,
-      });
-      return queryClient.invalidateQueries({
-        queryKey: ["users", variables.user._id, "posts"],
-      });
-    },
+    onSuccess: (_data, variables) =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["posts", variables._id],
+          exact: false,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["users", variables.user._id, "posts"],
+        }),
+      ]),
   });
 }


### PR DESCRIPTION
- Reduced the effect of request waterfall in `postDetailsLoader` by allowing independent queries to run simultaneously.
- Changed `onSuccess` callback of `usePostDelete` mutation hook to return a new promise based on both `invalidateQueries` calls.