### PR TITLE
chore: Change usersByUsername query key to store boolean flags in object

### DIFF
--- a/src/features/core/api/queries.ts
+++ b/src/features/core/api/queries.ts
@@ -24,7 +24,7 @@ const followQuery = (targetId: ObjectId) => ({
 });
 
 const usersByUsernameQuery = (username: string, partial: boolean = false) => ({
-  queryKey: ["users", username, partial],
+  queryKey: ["users", username, { partial }],
   queryFn: async () => getUsersByUsername(username, partial),
   staleTime: 1 * 60 * 1000,
 });


### PR DESCRIPTION
This PR moves `partial` search flag into an object within the query key array of `useUsersByUSernameQuery` to better show intent and avoid potential errors in the future in case of additional search params/flags being used.